### PR TITLE
Examples from Manual should be working

### DIFF
--- a/typo3/sysext/linkvalidator/Documentation/Configuration/Index.rst
+++ b/typo3/sysext/linkvalidator/Documentation/Configuration/Index.rst
@@ -27,7 +27,7 @@ Reference
 You can set the following options in the TSconfig for a page (e.g. the
 root page) and override them in user or groups TSconfig. You must
 prefix them with mod.linkvalidator, e.g.
-:code:`mod.linkvalidator.searchFields.pages = media`.
+:code:`mod.linkvalidator.searchFields.pages = canonical_link`.
 
 
 
@@ -47,17 +47,28 @@ searchFields.[key]
    Description
          Comma separated list of table fields in which to check for broken
          links.
+         
+         
+         This configuration only works for fields having at least one softref set in its TCA Configuration.
+
+         i.e. 
+         :code:`mod.linkvalidator.searchFields.pages = canonical_link` would work as 
+         :php:`$TCA['pages']['columns'][FIELD_NAME]['config']['softref'] == 'typolink'`
+         
+         :code:`mod.linkvalidator.searchFields.pages = media` would not work as the config field for media has no softref set.
 
          **Example** :
 
          ::
 
-            pages = media,url
+            pages = canonical_link
+            
+         
 
    Default
          .. code-block:: typoscript
 
-            pages = media,url
+            pages = media,url 
             tt_content = bodytext,header_link,records
 
 
@@ -275,7 +286,7 @@ Example
 
    mod.linkvalidator {
            searchFields {
-                   pages = media,url
+                   pages = canonical_link
                    tt_content = bodytext,header_link,records
            }
            linktypes = db,file,external


### PR DESCRIPTION
Fields without softref are not being checked. Since pages:media does not have Softref set in its TCA it will never get checked.  Field pages:url has an unresolved issue since 6 years. So better don't mention it as an example for configuration until it works. All of this has been the same since at least TYPO3 8.7. So the information can be backported.
The default configuration also contains the two not working fields. It causes users and administrators to feel wrongly in safety. We had a non-working External Link in the menu of our customer (level 4 so not easy to detect) and trusted on being notified if something in pages:url is not working.