### PR TITLE
Update Deprecation-89139-ConsoleCommandsConfigurationFormatCommandsPh…

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/10.3/Deprecation-89139-ConsoleCommandsConfigurationFormatCommandsPhp.rst
+++ b/typo3/sysext/core/Documentation/Changelog/10.3/Deprecation-89139-ConsoleCommandsConfigurationFormatCommandsPhp.rst
@@ -50,7 +50,7 @@ to false to exclude the command from the TYPO3 scheduler.
         autoconfigure: true
         public: false
 
-      MyVendor\MyExt\Commands\FooCommand
+      MyVendor\MyExt\Commands\FooCommand:
         tags:
           - name: 'console.command',
             command: 'my:command'
@@ -61,7 +61,7 @@ The optional tag attribute :yaml:`alias` should be set to true for alias command
 
 .. code-block:: yaml
 
-      MyVendor\MyExt\Commands\BarCommand
+      MyVendor\MyExt\Commands\BarCommand:
         tags:
           - name: 'console.command'
             command: 'my:bar'


### PR DESCRIPTION
…p.rst

Configuration is wrong, Symfony yaml expects double points instead of writing without.