### PR TITLE
Update Important-94484-IntroduceHTMLSanitizer.rst

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/9.5.x/Important-94484-IntroduceHTMLSanitizer.rst
+++ b/typo3/sysext/core/Documentation/Changelog/9.5.x/Important-94484-IntroduceHTMLSanitizer.rst
@@ -187,7 +187,7 @@ of :file:`typo3conf/LocalConfiguration.php`.
         'TYPO3' => [
             'HtmlSanitizer' => [
                 'writerConfiguration' => [
-                    'debug' => [
+                    \TYPO3\CMS\Core\Log\LogLevel::DEBUG => [
                         'TYPO3\CMS\Core\Log\Writer\FileWriter' => [
                             'logFileInfix' => 'html',
                         ],


### PR DESCRIPTION
Updating Logger configuration as the code gives the following error otherwise:

The given severity level "debug" for writerConfiguration of logger "TYPO3.HtmlSanitizer.Visitor.CommonVisitor" is not valid.