### PR TITLE
RootPaths are not ordered/sorted!

### DIFF
--- a/typo3/sysext/form/Classes/Domain/Renderer/FluidFormRenderer.php
+++ b/typo3/sysext/form/Classes/Domain/Renderer/FluidFormRenderer.php
@@ -153,18 +153,24 @@ class FluidFormRenderer extends AbstractElementRenderer
                 sprintf('The option templateRootPaths must be set for renderable "%s"', $formElementType),
                 1480293084
             );
+        } else {
+        	    ksort($renderingOptions['templateRootPaths']);
         }
         if (!isset($renderingOptions['layoutRootPaths'])) {
             throw new RenderingException(
                 sprintf('The option layoutRootPaths must be set for renderable "%s"', $formElementType),
                 1480293085
             );
+        } else {
+        	    ksort($renderingOptions['layoutRootPaths']);
         }
         if (!isset($renderingOptions['partialRootPaths'])) {
             throw new RenderingException(
                 sprintf('The option partialRootPaths must be set for renderable "%s"', $formElementType),
                 1480293086
             );
+        } else {
+        	    ksort($renderingOptions['partialRootPaths']);
         }
 
         $view->assign('form', $this->formRuntime);


### PR DESCRIPTION
Maybe somewhere else would be a better place to sort, after i added kSort for all Paths i could finally override all Form Templates