### PR TITLE
Fixed saveAndClose Issue

### DIFF
--- a/typo3/sysext/backend/Classes/Controller/ContentElement/NewContentElementController.php
+++ b/typo3/sysext/backend/Classes/Controller/ContentElement/NewContentElementController.php
@@ -221,6 +221,7 @@ class NewContentElementController
                         $parameters['data']['tt_content'][$id]['sys_language_uid'] = $this->sys_language;
                         $parameters['redirect'] = $this->R_URI;
                         $viewVariables['target'] = (string)$this->uriBuilder->buildUriFromRoute('tce_db', $parameters);
+                        unset($parameters);
                     } else {
                         $viewVariables['target'] = (string)$this->uriBuilder->buildUriFromRoute('record_edit', [
                             'edit' => [


### PR DESCRIPTION
Unset `$parameters` after creating the uri, otherwise `$parameters` will keep the settings for all previous elements with `saveAndClose` set to `1`, resulting in every previously registered element getting added to the page.