### PR TITLE
Update core/ext_tables.sql

### DIFF
--- a/typo3/sysext/core/ext_tables.sql
+++ b/typo3/sysext/core/ext_tables.sql
@@ -405,6 +405,7 @@ CREATE TABLE sys_language (
 #
 CREATE TABLE sys_category (
 	title tinytext NOT NULL,
+	parent int(11) DEFAULT '0' NOT NULL,
 	items int(11) DEFAULT '0' NOT NULL,
 
 	KEY category_parent (parent),


### PR DESCRIPTION
Add field parent to sys_category. Backend error if this field is not exited.