### PR TITLE
Typo in code documentation

### DIFF
--- a/typo3/sysext/form/Documentation/I/Concepts/Validators/Index.rst
+++ b/typo3/sysext/form/Documentation/I/Concepts/Validators/Index.rst
@@ -182,7 +182,7 @@ The 'Number range validator' checks if the given value is a number in
 the specified range. The validator has 2 options:
 
 - Minimum: The minimum value to accept.
-- Maximum: The maximum vlaue to accept.
+- Maximum: The maximum value to accept.
 
 
 .. _concepts-validators-mimetype:


### PR DESCRIPTION
Hello,
there was a small typo in the "number range validator" section.
(https://docs.typo3.org/c/typo3/cms-form/main/en-us/I/Concepts/Validators/Index.html#number-range-validator)

Have a nice day.
Fabio