### PR TITLE
ClickEnlargeViewhelper PHP 8.0/8.1 compatibility

### DIFF
--- a/typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php
+++ b/typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php
@@ -1015,7 +1015,7 @@ class ContentObjectRenderer implements LoggerAwareInterface
             }
             foreach ($parameterNames as $parameterName) {
                 if (isset($conf[$parameterName . '.'])) {
-                    $conf[$parameterName] = $this->stdWrap($conf[$parameterName], $conf[$parameterName . '.'] ?? []);
+                    $conf[$parameterName] = $this->stdWrap($conf[$parameterName] ?? '', $conf[$parameterName . '.'] ?? []);
                 }
                 if (isset($conf[$parameterName]) && $conf[$parameterName]) {
                     $parameters[$parameterName] = $conf[$parameterName];


### PR DESCRIPTION
Fixes 'Undefined array key "crop"' exception in PHP 8.0/8.1 when rendering an image with enabled clickenlarge and defined cropVariants.