### PR TITLE
[Bugfix] PHP 8.0/8.1 compatibility for Importer

### DIFF
--- a/typo3/sysext/impexp/Classes/Import.php
+++ b/typo3/sysext/impexp/Classes/Import.php
@@ -1557,7 +1557,7 @@ class Import extends ImportExport
                             break;
                         case 'db':
                         default:
-                            [$tempTable, $tempUid] = explode(':', (string)($softref['subst']['recordRef'] ?? ''));
+                            [$tempTable, $tempUid] = explode(':', (string)($softref['subst']['recordRef'] ?? ':'));
                             if (isset($this->importMapId[$tempTable][$tempUid])) {
                                 $insertValue = BackendUtility::wsMapId($tempTable, $this->importMapId[$tempTable][$tempUid]);
                                 $tokenValue = (string)$softref['subst']['tokenValue'];


### PR DESCRIPTION
Importer fails to process soft references (e.g. phone numbers, email, links etc.) in PHP 8.0/8.1 with "Undefined array key 1" as the string cannot split into two variables. Simple workaround is to define a colon as default value.