### PR TITLE
[Bugfix] PHP 8.0/8.1 compatibility ContentObjectRenderer

### DIFF
--- a/typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php
+++ b/typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php
@@ -1251,7 +1251,7 @@ class ContentObjectRenderer implements LoggerAwareInterface
                         // Check if there's already content available before processing
                         // any ifEmpty or ifBlank stdWrap properties
                         if (($functionName === 'ifBlank' && $content !== '') ||
-                            ($functionName === 'ifEmpty' && trim($content) !== '')) {
+                            ($functionName === 'ifEmpty' && trim((string)$content) !== '')) {
                             continue;
                         }
 


### PR DESCRIPTION
Fixed ContentObjectRender to cast also null values to string before trimming them.