### PR TITLE
[Feature] Add option to recursive fetch data for config.cache

### DIFF
--- a/typo3/sysext/frontend/Classes/Controller/TypoScriptFrontendController.php
+++ b/typo3/sysext/frontend/Classes/Controller/TypoScriptFrontendController.php
@@ -38,6 +38,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction;
+use TYPO3\CMS\Core\Database\QueryGenerator;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Error\Http\AbstractServerErrorException;
 use TYPO3\CMS\Core\Error\Http\PageNotFoundException;
@@ -3146,7 +3147,7 @@ class TypoScriptFrontendController implements LoggerAwareInterface
     {
         $now = (int)$now;
         $result = PHP_INT_MAX;
-        [$tableName, $pid] = GeneralUtility::trimExplode(':', $tableDef);
+        [$tableName, $pid, $recursive] = GeneralUtility::trimExplode(':', $tableDef);
         if (empty($tableName) || empty($pid)) {
             throw new \InvalidArgumentException('Unexpected value for parameter $tableDef. Expected <tablename>:<pid>, got \'' . htmlspecialchars($tableDef) . '\'.', 1307190365);
         }
@@ -3183,16 +3184,31 @@ class TypoScriptFrontendController implements LoggerAwareInterface
         // if starttime or endtime are defined, evaluate them
         if (!empty($timeFields)) {
             // find the timestamp, when the current page's content changes the next time
-            $row = $queryBuilder
+            $queryBuilder
                 ->from($tableName)
-                ->where(
+                ->where($timeConditions);
+
+            if (! filter_var($recursive, FILTER_VALIDATE_BOOLEAN)) {
+                // if not recursive, only use given pid to fetch items
+                $queryBuilder->andWhere(
                     $queryBuilder->expr()->eq(
                         'pid',
                         $queryBuilder->createNamedParameter($pid, \PDO::PARAM_INT)
                     ),
-                    $timeConditions
-                )
-                ->executeQuery()
+                );
+            }
+
+            if (filter_var($recursive, FILTER_VALIDATE_BOOLEAN)) {
+                // if recursive, fetch the subpages of given pid and add them to the query
+                $queryGenerator = GeneralUtility::makeInstance(QueryGenerator::class);
+                $pageTree = explode(',', $queryGenerator->getTreeList((int) $pid, 999, 0, 'and hidden = 0'));
+                $queryBuilder->andWhere(
+                    $queryBuilder->expr()->in('pid', $pageTree)
+                );
+            }
+
+            $row = $queryBuilder
+                ->execute()
                 ->fetchAssociative();
 
             if ($row) {


### PR DESCRIPTION
This adds a third parameter to the `config.cache` configuration. The
parameter is optional set to false by default.
Records from any subfolder are considered in the calculation of the
cache-lifetime by starttime/endtime.

The idea aims at pages with many nested sysfolders for records.
Specifying all the directories manually can be a lot of work.

Use it by adding a third parameter like in this example:
`config.cache.123 = tx_my_table:456:1`
to clear the cache on page 123 when a record found in page 456
or any nested subfolder reaches its starttime/endtime