### PR TITLE
[Bugfix] RecordHistory PHP 8.0/8.1 compatibility

### DIFF
--- a/typo3/sysext/backend/Classes/History/RecordHistory.php
+++ b/typo3/sysext/backend/Classes/History/RecordHistory.php
@@ -465,6 +465,7 @@ class RecordHistory
      */
     protected function sanitizeElementValue($value): string
     {
+        $value = (string)$value;
         if ($value !== '' && !preg_match('#^[a-z\d_.]+:[\d]+$#i', $value)) {
             return '';
         }
@@ -479,6 +480,7 @@ class RecordHistory
      */
     protected function sanitizeRollbackFieldsValue($value): string
     {
+        $value = (string)$value;
         if ($value !== '' && !preg_match('#^[a-z\d_.]+(:[\d]+(:[a-z\d_.]+)?)?$#i', $value)) {
             return '';
         }


### PR DESCRIPTION
When passing null as $value parameter, an exception is thrown as the return value must be of type string.