### PR TITLE
Remove superfluous function call

### DIFF
--- a/typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php
+++ b/typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php
@@ -3091,7 +3091,7 @@ class ContentObjectRenderer implements LoggerAwareInterface
                 $objName = (int)$splitArr[$a]['cObjNum'];
                 $value = (string)(isset($conf[$objName . '.'])
                     ? $this->stdWrap($this->cObjGet($conf[$objName . '.'], $objName . '.'), $conf[$objName . '.'])
-                    : $this->cObjGet($conf[$objName . '.'], $objName . '.'));
+                    : '';
             }
             $wrap = (string)$this->stdWrapValue('wrap', $splitArr[$a] ?? []);
             if ($wrap) {


### PR DESCRIPTION
the function call seems superfluous, the condition tests if the array key exists, so the first parameter should be empty, the called function cObjGet tests if the first parameter is an array, if not, an empty string is returned. So i think we could use the empty string directly.