### PR TITLE
[BUGFIX] PHP 8.0/8.1 compatibility

### DIFF
--- a/typo3/sysext/backend/Classes/Form/Container/FlexFormSectionContainer.php
+++ b/typo3/sysext/backend/Classes/Form/Container/FlexFormSectionContainer.php
@@ -115,7 +115,7 @@ class FlexFormSectionContainer extends AbstractContainer
         }
 
         $sectionTitle = '';
-        if (!empty(trim($flexFormDataStructureArray['title']))) {
+        if (!empty(trim($flexFormDataStructureArray['title'] ?? ''))) {
             $sectionTitle = $languageService->sL(trim($flexFormDataStructureArray['title']));
         }
 


### PR DESCRIPTION
FlexFormSectionContainer raises an exception when title is not defined. To reproduce install solr 11.5-beta-2 and try to set up a search form plugin on any page.