### PR TITLE
Update WorkspaceService.php

### DIFF
--- a/typo3/sysext/workspaces/Classes/Service/WorkspaceService.php
+++ b/typo3/sysext/workspaces/Classes/Service/WorkspaceService.php
@@ -655,7 +655,7 @@ class WorkspaceService implements SingletonInterface
             $pageList = [];
             foreach ($mountPoints as $mountPoint) {
                 $pageList = array_merge(
-                    $pageList
+                    $pageList,
                     [ (int)$mountPoint ],
                     $this->getPageChildrenRecursive((int)$mountPoint, (int)$recursionLevel, 0, $permsClause)
                 );


### PR DESCRIPTION
missing komma in php-function array_merge on line 658 results in PHP_Warning or Error when calling the function:

from 
array_merge($pageList [ (int)$mountPoint ],$this->getPageChildrenRecursive((int)$mountPoint, (int)$recursionLevel, 0, $permsClause));

to 
array_merge($pageList, [ (int)$mountPoint ],$this->getPageChildrenRecursive((int)$mountPoint, (int)$recursionLevel, 0, $permsClause));

all array need to be seperated by comma