### PR TITLE
TASK respect datetime dbtype field

### DIFF
--- a/typo3/sysext/backend/Classes/Utility/BackendUtility.php
+++ b/typo3/sysext/backend/Classes/Utility/BackendUtility.php
@@ -1619,8 +1619,8 @@ class BackendUtility
 
                     if (GeneralUtility::inList($theColConf['eval'] ?? '', 'date')) {
                         // Handle native date field
-                        if (isset($theColConf['dbType']) && $theColConf['dbType'] === 'date') {
-                            $value = $value === $dateTimeFormats['date']['empty'] ? 0 : (int)strtotime($value);
+                        if (isset($theColConf['dbType']) && ($theColConf['dbType'] === 'date' || $theColConf['dbType'] === 'datetime')) {
+                            $value = $value === $dateTimeFormats[$theColConf['dbType']]['empty'] ? 0 : (int)strtotime($value);
                         } else {
                             $value = (int)$value;
                         }


### PR DESCRIPTION
if TCA uses dbtype datetime its converted to int and ends in invalid timestamp. this fix prevent this and shows the correct date in history view.