### PR TITLE
[BUGFIX] folder renaming PHP 8.0/8.1 compatibility

### DIFF
--- a/typo3/sysext/core/Classes/Resource/ResourceFactory.php
+++ b/typo3/sysext/core/Classes/Resource/ResourceFactory.php
@@ -282,7 +282,7 @@ class ResourceFactory implements SingletonInterface
     {
         // Remove Environment::getPublicPath() because absolute paths under Windows systems contain ':'
         // This is done in all considered sub functions anyway
-        $input = str_replace(Environment::getPublicPath() . '/', '', $input);
+        $input = str_replace(Environment::getPublicPath() . '/', '', (string)$input);
 
         if (str_starts_with($input, 'file:')) {
             $input = substr($input, 5);


### PR DESCRIPTION
When renaming a folder within the filelist module of the backend an exception is thrown, because the input parameter is null. Typecasting ensures backwards compatibility.