### PR TITLE
[BUGFIX] Template Analyzer PHP 8.0/8.1 compatibility

### DIFF
--- a/typo3/sysext/tstemplate/Classes/Controller/TemplateAnalyzerController.php
+++ b/typo3/sysext/tstemplate/Classes/Controller/TemplateAnalyzerController.php
@@ -119,7 +119,7 @@ class TemplateAnalyzerController extends TypoScriptTemplateModuleController
         }
         $thisLineOffset = $nextLineOffset = 0;
         foreach ($templates as $templateNumber => $templateContent) {
-            $templateId = $this->templateService->hierarchyInfo[$templateNumber]['templateID'];
+            $templateId = $this->templateService->hierarchyInfo[$templateNumber]['templateID'] ?? null;
             $templateTitle = $this->templateService->hierarchyInfo[$templateNumber]['title'] ?? 'Template';
             // Prefix content with '[GLOBAL]' even for empty strings, the TemplateService does that, too.
             // Not replicating this leads to shifted line numbers when parser errors are reported in FE and object browser.


### PR DESCRIPTION
When accessing the Template Analyzer an exception 'undefined array key 7' is thrown.