### PR TITLE
Fixed spelling of "includeJSFooterlibs"

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/7.3/Feature-66698-AddIntegrityPropertyToJavaScriptFiles.rst
+++ b/typo3/sysext/core/Documentation/Changelog/7.3/Feature-66698-AddIntegrityPropertyToJavaScriptFiles.rst
@@ -17,7 +17,7 @@ Add a property `integrity="some-hash"` to JavaScript files via TypoScript
 This patch affects the TypoScript PAGE properties
 
 * includeJSLibs
-* includeJSFooterLibs
+* includeJSFooterlibs
 * includeJS
 * includeJSFooter
 


### PR DESCRIPTION
In accordance with the core code base, "libs" in "includeJSFooterlibs" must be lowercase.