### PR TITLE
[BUGFIX] PageCopy with nested ContentElements(GridElements) l10n_source is set to uid of translated Element of old page

### DIFF
--- a/typo3/sysext/core/Classes/DataHandling/DataHandler.php
+++ b/typo3/sysext/core/Classes/DataHandling/DataHandler.php
@@ -3516,7 +3516,7 @@ class DataHandler implements LoggerAwareInterface
                             )
                         );
                     if (!empty($GLOBALS['TCA'][$table]['ctrl']['sortby'])) {
-                        $queryBuilder->orderBy($GLOBALS['TCA'][$table]['ctrl']['sortby'], 'DESC');
+                        $queryBuilder->orderBy($GLOBALS['TCA'][$table]['ctrl']['sortby'], 'ASC');
                     }
                     $queryBuilder->addOrderBy('uid');
                     try {


### PR DESCRIPTION
Fixes order for copying nested indented content elements to get correct values for l10n_source of translated CE's on a copied page.
See https://forge.typo3.org/issues/97469 for more informations.

Resolves: #97469
Releases: 10.4