### PR TITLE
[BUGFIX] Replace array notation with string for value of allowedAttribs

### DIFF
--- a/typo3/sysext/rte_ckeditor/Configuration/RTE/Processing.yaml
+++ b/typo3/sysext/rte_ckeditor/Configuration/RTE/Processing.yaml
@@ -81,8 +81,7 @@ processing:
     denyTags: img
     tags:
       hr:
-        allowedAttribs:
-          - class
+        allowedAttribs: "class"
 
     ## REMOVE OPEN OFFICE META DATA TAGS, WORD 2003 TAGS, LINK, META, STYLE AND TITLE TAGS, AND DEPRECATED HTML TAGS
     ## We use this rule instead of the denyTags rule so that we can protect custom tags without protecting these unwanted tags.


### PR DESCRIPTION
According to \TYPO3\CMS\Core\Html\HtmlParser::HTMLcleaner() the value of property "allowedAttribs" needs to be a commalist of attributes (string value) instead of an array.

Tests have also shown that despite the default setting, the class attribute for hr tags is currently stripped when the record is saved. This fix ensures that the class attribute is preserved as originally intended.