### PR TITLE
[BUGFIX] Load only LIVE records in checkIfPageIsHidden

### DIFF
--- a/typo3/sysext/core/Classes/Domain/Repository/PageRepository.php
+++ b/typo3/sysext/core/Classes/Domain/Repository/PageRepository.php
@@ -2044,7 +2044,8 @@ class PageRepository implements LoggerAwareInterface
         $queryBuilder
             ->getRestrictions()
             ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
+            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class));
 
         $queryBuilder
             ->select('uid', 'hidden', 'starttime', 'endtime')


### PR DESCRIPTION
The `checkIfPageIsHidden` queries the page and afterwards performs the workspace overlay.
However the first query can also load workspaced records, because the restriction is missing, which means changes in the workspace can affect the preview functionality of LIVE.
Most of the times this won't break, because of the `LIMIT 1` and normally in the database the WS records will be stored after the LIVE record.

We first identified this bug in TYPO3 v10, where this bug is in `TypoScriptFrontendController`: https://github.com/TYPO3/typo3/blob/11.5/typo3/sysext/frontend/Classes/Controller/TypoScriptFrontendController.php#L852
There you can see there is a check for `pid > 0` in the query which is the legacy way of saying "no workspace version".