### PR TITLE
[DOCS] correct text-role

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/12.0/Breaking-97550-TypoScriptOptionConfigdisableCharsetHeaderRemoved.rst
+++ b/typo3/sysext/core/Documentation/Changelog/12.0/Breaking-97550-TypoScriptOptionConfigdisableCharsetHeaderRemoved.rst
@@ -11,7 +11,7 @@ See :issue:`97550`
 Description
 ===========
 
-The TypoScript flag :ts:`config.disableCharsetHeader` has been completely removed
+The TypoScript flag :typoscript:`config.disableCharsetHeader` has been completely removed
 from TYPO3 Core.
 
 This option was used to avoid sending HTTP headers of type "Content-Type" to


### PR DESCRIPTION
The text role `:ts:` may only be used for typescript, not typoscript. It does therefore not render.