### PR TITLE
Replace single quotes by double quotes in annotations

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/11.0/Feature-91719-CustomErrorMessagesInRegularExpressionValidator.rst
+++ b/typo3/sysext/core/Documentation/Changelog/11.0/Feature-91719-CustomErrorMessagesInRegularExpressionValidator.rst
@@ -29,8 +29,8 @@ Example:
         * @TYPO3\CMS\Extbase\Annotation\Validate(
         *    "RegularExpression",
         *    options={
-        *       "regularExpression": '/^SO[0-9]$/',
-        *       "errorMessage": 'explain how to provide a valid value'
+        *       "regularExpression": "/^SO[0-9]$/",
+        *       "errorMessage": "explain how to provide a valid value"
         *    }
         * )
         */


### PR DESCRIPTION
Doctrine (now?) doe not allow values to be surrounded by single quotes. It expects a `PlainValue` but struggles over the quotes. Replacing the single with double quotes solves this.
`[Syntax Error] Expected PlainValue, got ''' at position ***`