### PR TITLE
[TASK] Name custom handlers in HTTP stack

### DIFF
--- a/typo3/sysext/core/Classes/Http/Client/GuzzleClientFactory.php
+++ b/typo3/sysext/core/Classes/Http/Client/GuzzleClientFactory.php
@@ -37,8 +37,8 @@ class GuzzleClientFactory
 
         if (isset($GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler']) && is_array($GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler'])) {
             $stack = HandlerStack::create();
-            foreach ($GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler'] ?? [] as $handler) {
-                $stack->push($handler);
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler'] ?? [] as $name => $handler) {
+                $stack->push($handler, (string)$name);
             }
             $httpOptions['handler'] = $stack;
         }


### PR DESCRIPTION
The Guzzle handler stack allows for pushing handlers/middlewares with a
name which simplifies debugging. A possibly defined handler name is now
pushed onto the stack as well.

Resolves: #97873
Releases: main, 11.5