### PR TITLE
[BUGFIX] prevent array access warning on deleted database record

### DIFF
--- a/typo3/sysext/backend/Classes/Form/Container/InlineRecordContainer.php
+++ b/typo3/sysext/backend/Classes/Form/Container/InlineRecordContainer.php
@@ -363,7 +363,7 @@ class InlineRecordContainer extends AbstractContainer
         // Renders a thumbnail for the header
         if (($GLOBALS['TYPO3_CONF_VARS']['GFX']['thumbnails'] ?? false) && !empty($inlineConfig['appearance']['headerThumbnail']['field'])) {
             $fieldValue = $rec[$inlineConfig['appearance']['headerThumbnail']['field']];
-            $fileUid = $fieldValue[0]['uid'];
+            $fileUid = $fieldValue[0]['uid'] ?? null;
 
             if (!empty($fileUid)) {
                 try {

--- a/typo3/sysext/backend/Classes/Form/FormDataProvider/DatabaseRecordTypeValue.php
+++ b/typo3/sysext/backend/Classes/Form/FormDataProvider/DatabaseRecordTypeValue.php
@@ -106,7 +106,7 @@ class DatabaseRecordTypeValue implements FormDataProviderInterface
                     // Fetch field of this foreign row from db
                     if (MathUtility::canBeInterpretedAsInteger($foreignUid)) {
                         $foreignRow = $this->getDatabaseRow($foreignTable, (int)$foreignUid, $foreignTableTypeField);
-                        if ($foreignRow[$foreignTableTypeField]) {
+                        if (empty($foreignRow[$foreignTableTypeField]) === false) {
                             // @todo: It might be necessary to fetch the value from default language record as well here,
                             // @todo: this was buggy in the "old" implementation and never worked. It was therefor left out here for now.
                             // @todo: To implement that, see if the foreign row is a localized overlay, fetch default and merge exclude

--- a/typo3/sysext/core/Classes/Resource/Service/UserFileInlineLabelService.php
+++ b/typo3/sysext/core/Classes/Resource/Service/UserFileInlineLabelService.php
@@ -45,7 +45,13 @@ class UserFileInlineLabelService
         }
 
         // In case of a group field uid_local is a resolved array
-        $fileRecord = $params['row']['uid_local'][0]['row'];
+        $fileRecord = $params['row']['uid_local'][0]['row'] ?? null;
+
+        if ($fileRecord === null) {
+            // no file record so nothing more to do
+            $params['title'] = $params['row']['uid'];
+            return;
+        }
 
         // Configuration
         $title = '';


### PR DESCRIPTION
if a sys_file record is directly deleted from database, some undefined array index warnings are triggered if the file is assigned to another database record.