### PR TITLE
[BUGFIX] missing option controls on youtube video with PHP8.0 .

### DIFF
--- a/typo3/sysext/core/Classes/Resource/Rendering/YouTubeRenderer.php
+++ b/typo3/sysext/core/Classes/Resource/Rendering/YouTubeRenderer.php
@@ -138,7 +138,9 @@ class YouTubeRenderer implements FileRendererInterface
         $videoId = $this->getVideoIdFromFile($file);
 
         $urlParams = ['autohide=1'];
-        $urlParams[] = 'controls=' . $options['controls'];
+        if (!empty($options['controls'])) {
+            $urlParams[] = 'controls=' . $options['controls'];
+        }
         if (!empty($options['autoplay'])) {
             $urlParams[] = 'autoplay=1';
             // If autoplay is enabled, enforce mute=1, see https://developer.chrome.com/blog/autoplay/


### PR DESCRIPTION
Hello,

after creating a Text & Media Element and adding a *.youtube file to the assets if was getting this error:

![image](https://user-images.githubusercontent.com/10448557/181482553-db4d1041-f027-49bc-9b41-a32dbb43407e.png)

With this small fix the exception doesnt appear anymore.

System:
TYPO3: 11.5.13
PHP: 8.0.16

DDEV Config for reproduce purpose:
```
name: test-headless
type: typo3
docroot: public
php_version: "8.0"
composer_version: "2"
nodejs_version: "16"
database:
  type: mysql
  version: "5.7"
webserver_type: apache-fpm
router_http_port: "80"
router_https_port: "443"
xdebug_enabled: true
additional_fqdns: [ ]
nfs_mount_enabled: true
mutagen_enabled: false
webimage_extra_packages: [ cron ]
use_dns_when_possible: true
timezone: Europe/Berlin
web_environment: [ ]
```

Best regards 
Fabio 