### PR TITLE
[TASK] Increase new password minimum length in FE

### DIFF
--- a/typo3/sysext/felogin/Configuration/TypoScript/constants.typoscript
+++ b/typo3/sysext/felogin/Configuration/TypoScript/constants.typoscript
@@ -54,7 +54,7 @@ styles.content.loginform {
   # cat=Frontend Login/06_Security/100; type=int+; label= Time in hours how long the link for forget password is valid: How many hours the link for forget password is valid
   forgotLinkHashValidTime = 12
   # cat=Frontend Login/06_Security/101; type=int+; label= Minimum amount of characters, when setting a new password: Minimum length of the new password a user sets
-  newPasswordMinLength = 6
+  newPasswordMinLength = 12
   # cat=Frontend Login/06_Security/102; type=string; label= Allowed Referrer-Redirect-Domains: Comma separated list of domains which are allowed for the referrer redirect mode
   domains =
   # cat=Frontend Login/06_Security/103; type=boolean; label= Expose existing users: Expose the information on whether or not the account for which a new password was requested exists. By default, that information is not disclosed for privacy reasons.


### PR DESCRIPTION
The original value of 6 was set in 2009, via 39441104649280393f3c54a5bb33b67be294f41a.
This is no longer a sensible value for any kind of system in 2022.