### PR TITLE
fix typo in language file

### DIFF
--- a/typo3/sysext/core/Resources/Private/Language/locallang_core.xlf
+++ b/typo3/sysext/core/Resources/Private/Language/locallang_core.xlf
@@ -1312,7 +1312,7 @@ Do you want to refresh it now?</source>
 				<source>Bookmark already exists</source>
 			</trans-unit>
 			<trans-unit id="toolbarItems.bookmarkAlreadyExistsMessage" resname="toolbarItems.bookmarkAlreadyExistsMessage">
-				<source>The document is already in your bookmaks.</source>
+				<source>The document is already in your bookmarks.</source>
 			</trans-unit>
 			<trans-unit id="toolbarItems.bookmarkFailedTitle" resname="toolbarItems.bookmarkFailedTitle">
 				<source>Bookmark creation failed</source>


### PR DESCRIPTION
This fixes a small typo I found while translating to german in Crowdin.