### PR TITLE
Fix invalid link

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/10.4/Deprecation-90625-ExtbaseSignalSlotDispatcher.rst
+++ b/typo3/sysext/core/Documentation/Changelog/10.4/Deprecation-90625-ExtbaseSignalSlotDispatcher.rst
@@ -55,6 +55,6 @@ Migration
 Use PSR-14 Events and Event-Listeners instead.
 
 See the documentation for details:
-https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Hooks/EventDispatcher/Index.html
+https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Events/EventDispatcher/Index.html
 
 .. index:: PHP-API, FullyScanned, ext:extbase


### PR DESCRIPTION
The link in the documentation is invalid, I suppose the document was moved from Hooks/EventDispatcher to Events/EventDispatcher. This change should also be backported to v11 and v10 documentation.