### PR TITLE
Replace typoscript getEnv with $_ENV

### DIFF
--- a/typo3/sysext/core/Classes/TypoScript/Parser/TypoScriptParser.php
+++ b/typo3/sysext/core/Classes/TypoScript/Parser/TypoScriptParser.php
@@ -482,7 +482,7 @@ class TypoScriptParser
                 $newValue = implode(',', $elements);
                 break;
             case 'getEnv':
-                $environmentValue = getenv(trim($modifierArgumentAsString));
+                $environmentValue = $_ENV[trim($modifierArgumentAsString)] ?? false;
                 if ($environmentValue !== false) {
                     $newValue = $environmentValue;
                 }


### PR DESCRIPTION
As per https://github.com/vlucas/phpdotenv#putenv-and-getenv it's discouraged to use getenv instead of $_ENV due to not being threadsafe. Furthermore using $_ENV instead of getenv will avoid a bug(?) that currently happens with symfony/dotenv where getenv will not return the env variable.

This change aims to allow usage of env in typoscript when using symfony/dotenv