### PR TITLE
sysext/install/Check: check PHP extension "tokenizer"

### DIFF
--- a/typo3/sysext/install/Classes/SystemEnvironment/Check.php
+++ b/typo3/sysext/install/Classes/SystemEnvironment/Check.php
@@ -74,6 +74,7 @@ class Check implements CheckInterface
         'session',
         'SPL',
         'standard',
+        'tokenizer',
         'xml',
         'zip',
         'zlib',


### PR DESCRIPTION
Various vendored libraries incorporated by Typo3 use the "token_get_all" function, crashing PHP execution if the "tokenizer" extension is not loaded.