### PR TITLE
Cache/ApcuBackend: eliminate double serialization

### DIFF
--- a/typo3/sysext/core/Classes/Cache/Backend/ApcuBackend.php
+++ b/typo3/sysext/core/Classes/Cache/Backend/ApcuBackend.php
@@ -40,7 +40,7 @@ use TYPO3\CMS\Core\Core\Environment;
  * This prefix makes sure that keys from the different installations do not
  * conflict.
  */
-class ApcuBackend extends AbstractBackend implements TaggableBackendInterface
+class ApcuBackend extends AbstractBackend implements TaggableBackendInterface, TransientBackendInterface
 {
     /**
      * A prefix to separate stored data from other data possible stored in the APC
@@ -111,9 +111,6 @@ class ApcuBackend extends AbstractBackend implements TaggableBackendInterface
     {
         if (!$this->cache instanceof FrontendInterface) {
             throw new Exception('No cache frontend has been set yet via setCache().', 1232986118);
-        }
-        if (!is_string($data)) {
-            throw new InvalidDataException('The specified data is of type "' . gettype($data) . '" but a string is expected.', 1232986125);
         }
         $tags[] = '%APCBE%' . $this->cacheIdentifier;
         $expiration = $lifetime ?? $this->defaultLifetime;


### PR DESCRIPTION
APCu can store arbitrary PHP data; it serializes all values when they are stored, and it has a pluggable serializer interface which can use serializers that are better than serialize(), such as "igbinary" (https://www.php.net/manual/en/book.igbinary.php and https://pecl.php.net/package/igbinary).

By not implementing TransientBackendInterface, the ApcuBackend forces class VariableFrontend to serialize all values into a string, but APCu serializes the string again.  This is unnecessary overhead.

This adds TransientBackendInterface and removes the is_string() check. Double serialization is eliminated by this change.