### PR TITLE
[BUGFIX] Ensure `uid` is not updated when updating resources

### DIFF
--- a/typo3/sysext/core/Classes/Resource/ProcessedFileRepository.php
+++ b/typo3/sysext/core/Classes/Resource/ProcessedFileRepository.php
@@ -197,6 +197,7 @@ class ProcessedFileRepository extends AbstractRepository implements LoggerAwareI
         if ($processedFile->isPersisted()) {
             $uid = (int)$processedFile->getUid();
             $updateFields = $this->cleanUnavailableColumns($processedFile->toArray());
+            unset($updateFields['uid']);
             $updateFields['tstamp'] = time();
 
             $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($this->table);


### PR DESCRIPTION
When updating entries, the `updateFields` will provide `uid`, which works fine in MySQL but might lead to problems when working with stricter DBMS.

Such an example of a DBMS not liking the update of an identity field, is SQL Server.

Now, I know that SQL Server will not be supported in TYPO3 v12 going onward, but on the off-chance that somebody has another DBMS than MySQL or has DBMS that will break when trying to update an identify field, this bugfix might still be valuable.

The bug exists back to TYPO3 10 at least.