### PR TITLE
[BUGFIX] Avoid exceptions while loading presets

### DIFF
--- a/typo3/sysext/impexp/Classes/Controller/ExportController.php
+++ b/typo3/sysext/impexp/Classes/Controller/ExportController.php
@@ -291,7 +291,7 @@ class ExportController
     protected function getRecordSelectOptions(array $inputData): array
     {
         $records = [];
-        foreach ($inputData['record'] as $tableNameColonUid) {
+        foreach ($inputData['record'] ?? [] as $tableNameColonUid) {
             [$tableName, $recordUid] = explode(':', $tableNameColonUid);
             if ($record = BackendUtility::getRecordWSOL((string)$tableName, (int)$recordUid)) {
                 $records[] = [
@@ -310,7 +310,7 @@ class ExportController
         $backendUser = $this->getBackendUser();
         $languageService = $this->getLanguageService();
         $tableList = [];
-        foreach ($inputData['list'] as $reference) {
+        foreach ($inputData['list'] ?? [] as $reference) {
             $referenceParts = explode(':', $reference);
             $tableName = $referenceParts[0];
             if ($backendUser->check('tables_select', $tableName)) {

--- a/typo3/sysext/impexp/Classes/ViewHelpers/InArrayViewHelper.php
+++ b/typo3/sysext/impexp/Classes/ViewHelpers/InArrayViewHelper.php
@@ -34,6 +34,6 @@ class InArrayViewHelper extends AbstractConditionViewHelper
 
     public static function verdict(array $arguments, RenderingContextInterface $renderingContext): bool
     {
-        return in_array($arguments['needle'], $arguments['haystack'], true);
+        return in_array($arguments['needle'], (array)$arguments['haystack'], true);
     }
 }


### PR DESCRIPTION
This patch avoids undefined key warning and properly casts the haystack
argument of the InArrayViewHelper to an array.

Resolves: #100748
Releases: main