### PR TITLE
fix invalid error level for php errors

### DIFF
--- a/typo3/sysext/core/Classes/Error/AbstractExceptionHandler.php
+++ b/typo3/sysext/core/Classes/Error/AbstractExceptionHandler.php
@@ -167,6 +167,7 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface, Si
                 'channel' => SystemLogType::toChannel(SystemLogType::ERROR),
                 'action' => SystemLogGenericAction::UNDEFINED,
                 'error' => SystemLogErrorClassification::SYSTEM_ERROR,
+                'level' => \Psr\Log\LogLevel::ERROR,
                 'details_nr' => 0,
                 'details' => str_replace('%', '%%', $logMessage),
                 'log_data' => empty($data) ? '' : json_encode($data),

--- a/typo3/sysext/core/Classes/Error/ErrorHandler.php
+++ b/typo3/sysext/core/Classes/Error/ErrorHandler.php
@@ -247,19 +247,6 @@ class ErrorHandler implements ErrorHandlerInterface, LoggerAwareInterface
                 }
             }
 
-            switch ($logLevel) {
-                case LogLevel::ERROR:
-                    $severity = 2;
-                    break;
-                case LogLevel::WARNING:
-                    $severity = 1;
-                    break;
-                case LogLevel::NOTICE:
-                default:
-                    $severity = 0;
-                    break;
-            }
-
             $connection->insert(
                 'sys_log',
                 [
@@ -268,7 +255,7 @@ class ErrorHandler implements ErrorHandlerInterface, LoggerAwareInterface
                     'channel' => SystemLogType::toChannel(SystemLogType::ERROR),
                     'action' => SystemLogGenericAction::UNDEFINED,
                     'error' => SystemLogErrorClassification::SYSTEM_ERROR,
-                    'level' => $severity,
+                    'level' => $logLevel,
                     'details_nr' => 0,
                     'details' => str_replace('%', '%%', $logMessage),
                     'log_data' => empty($data) ? '' : json_encode($data),


### PR DESCRIPTION
- PHP exceptions were logged with level "info" in the sys_log table
- PHP errors were logged with wrong (numeric) error level in the sys_log table
Only values from `\Psr\Log\LogLevel` are allowed and usable. Numeric values can not be used/filtered in BeLog.