### PR TITLE
Respect TCA overrides for CE localization

### DIFF
--- a/typo3/sysext/core/Classes/DataHandling/DataHandler.php
+++ b/typo3/sysext/core/Classes/DataHandling/DataHandler.php
@@ -4552,8 +4552,18 @@ class DataHandler implements LoggerAwareInterface
             // @todo: Possible bug here? type can be something like 'table:field', which is then null in $row, writing null to $overrideValues
             $overrideValues[$GLOBALS['TCA'][$table]['ctrl']['type']] = $row[$GLOBALS['TCA'][$table]['ctrl']['type']] ?? null;
         }
+
+        $tcaCols = $GLOBALS['TCA'][$table]['columns'];
+        $cType = $row['CType'];
+        if ($cType) {
+            $overrides = $GLOBALS['TCA'][$table]['types'][$cType]['columnsOverrides'] ?? null;
+            if ($overrides) {
+                $tcaCols = array_replace_recursive($tcaCols, $overrides);
+            }
+        }
+        
         // Set exclude Fields:
-        foreach ($GLOBALS['TCA'][$table]['columns'] as $fN => $fCfg) {
+        foreach ($tcaCols as $fN => $fCfg) {
             $translateToMsg = '';
             // Check if we are just prefixing:
             if (isset($fCfg['l10n_mode']) && $fCfg['l10n_mode'] === 'prefixLangTitle') {


### PR DESCRIPTION
I have a few general purpose columns, that are shared between CTypes. The implementation differs between them, and is setup via overrides for the specific CType.

DataHandler->localize doesn't seem to respect column overrides for CTypes, resulting in settings like `l10n_mode` being ignored, if they are set via CType specific override.

The scenario where I ran into this, was trying to translate one of the general purpose columns via https://github.com/web-vision/wv_deepltranslate/. The columns were ignored, because it didn't detect the `'l10n_mode' => 'prefixLangTitle'`, which had to be set via overrides in my case.

This pull request adds the handling of CType specific overrides in DataHandler->localize.