### PR TITLE
Fixed typoscript example for enabling the index for EXT:indexed_search

### DIFF
--- a/typo3/sysext/indexed_search/Documentation/Configuration/General/Index.rst
+++ b/typo3/sysext/indexed_search/Documentation/Configuration/General/Index.rst
@@ -21,7 +21,7 @@ typical), then you will have to set this config-option:
 
 .. code-block:: typoscript
 
-   page.config.index_enable = 1
+   config.index_enable = 1
 
 When this option is set you should begin to see your pages being
 indexed when they are shown next time. Remember that only cached pages


### PR DESCRIPTION
Shouldn't this be `config.index_enable` instead of `page.config.index_enable` ? According to the settings inside **EXT:indexed_search/Configuration/TypoScript/setup.typoscript** there is no page object around it and the settings for the language below don't habe a page-object around it too.