### PR TITLE
[BUGFIX] Fix new forms from predefined core form have no validation

### DIFF
--- a/typo3/sysext/form/Resources/Private/Backend/Templates/FormEditor/Yaml/NewForms/SimpleContactForm.yaml
+++ b/typo3/sysext/form/Resources/Private/Backend/Templates/FormEditor/Yaml/NewForms/SimpleContactForm.yaml
@@ -25,32 +25,33 @@ renderables:
     identifier: page-1
     label: 'Contact Form'
     type: Page
-
     renderables:
       -
+        defaultValue: ''
         identifier: name
         label: 'Name'
         type: Text
         properties:
           fluidAdditionalAttributes:
             placeholder: 'Name'
-            autocomplete: name
-        defaultValue: ''
+            required: required
         validators:
           -
             identifier: NotEmpty
       -
+        defaultValue: ''
         identifier: subject
         label: 'Subject'
         type: Text
         properties:
           fluidAdditionalAttributes:
             placeholder: 'Subject'
-        defaultValue: ''
+            required: required
         validators:
           -
             identifier: NotEmpty
       -
+        defaultValue: ''
         identifier: email
         label: 'Email'
         type: Email
@@ -58,20 +59,21 @@ renderables:
           fluidAdditionalAttributes:
             placeholder: 'Email address'
             autocomplete: email
-        defaultValue: ''
+            required: required
         validators:
           -
             identifier: NotEmpty
           -
             identifier: EmailAddress
       -
+        defaultValue: ''
         identifier: message
         label: 'Message'
         type: Textarea
         properties:
           fluidAdditionalAttributes:
             placeholder: ''
-        defaultValue: ''
+            required: required
         validators:
           -
             identifier: NotEmpty


### PR DESCRIPTION
We have noticed in our project, when creating a new form from the predefined from "SimpleContactForm" that the fields are marked as required, but do not actually have the fluidAdditionalAttribute required until the field was clicked at and saved.

In order to fix this, this Pull Request adds the missing attribute.