### PR TITLE
Get mapping results for non-formObject properties

### DIFF
--- a/typo3/sysext/fluid/Classes/ViewHelpers/Form/AbstractFormFieldViewHelper.php
+++ b/typo3/sysext/fluid/Classes/ViewHelpers/Form/AbstractFormFieldViewHelper.php
@@ -352,17 +352,21 @@ abstract class AbstractFormFieldViewHelper extends AbstractFormViewHelper
      */
     protected function getMappingResultsForProperty(): Result
     {
-        if (!$this->isObjectAccessorMode()) {
+        if ($this->isObjectAccessorMode()) {
+            $formObjectName = $this->renderingContext->getViewHelperVariableContainer()->get(
+                FormViewHelper::class,
+                'formObjectName'
+            );
+            $propertyPath = $formObjectName . '.' . (string)$this->arguments['property'];
+        } elseif ($this->arguments['name'] ?? '') {
+            $propertyPath = rtrim(preg_replace('/(\\]\\[|\\[|\\])/', '.', $this->arguments['name']) ?? '', '.');
+        } else {
             return new Result();
         }
         /** @var ExtbaseRequestParameters $extbaseRequestParameters */
         $extbaseRequestParameters = $this->getRequest()->getAttribute('extbase');
         $originalRequestMappingResults = $extbaseRequestParameters->getOriginalRequestMappingResults();
-        $formObjectName = $this->renderingContext->getViewHelperVariableContainer()->get(
-            FormViewHelper::class,
-            'formObjectName'
-        );
-        return $originalRequestMappingResults->forProperty($formObjectName)->forProperty((string)$this->arguments['property']);
+        return $originalRequestMappingResults->forProperty($propertyPath);
     }
 
     /**


### PR DESCRIPTION
The case is for validating a ValueObject in a <f:form>. When its property is invalid, the `errorClass` is added now.

See https://forge.typo3.org/issues/86829.