### PR TITLE
[FEATURE] Allows you to save date without time

### DIFF
--- a/typo3/sysext/extbase/Classes/Property/TypeConverter/DateTimeConverter.php
+++ b/typo3/sysext/extbase/Classes/Property/TypeConverter/DateTimeConverter.php
@@ -128,6 +128,9 @@ class DateTimeConverter extends AbstractTypeConverter
             $date = $targetType::createFromFormat($dateFormat, $dateAsString);
         }
         if ($date === false) {
+            $date = $targetType::createFromFormat( str_replace( ["\\",":","TH","H","i","s","P"], "", $dateFormat ) , $dateAsString);
+		}
+        if ($date === false) {
             return new \TYPO3\CMS\Extbase\Validation\Error('The date "%s" was not recognized (for format "%s").', 1307719788, [$dateAsString, $dateFormat]);
         }
         if (is_array($source)) {


### PR DESCRIPTION
If the value passed is a date without time, an attempt is made to convert. To do this, the time information is removed from $dateFormat.