### PR TITLE
Catch exception and return new instance of ContentObjectRenderer

### DIFF
--- a/typo3/sysext/extbase/Classes/Mvc/Web/Routing/UriBuilder.php
+++ b/typo3/sysext/extbase/Classes/Mvc/Web/Routing/UriBuilder.php
@@ -696,9 +696,13 @@ class UriBuilder
             E_USER_DEPRECATED
         );
 
-        return ($contentObject = $this->getRequest()?->getAttribute('currentContentObject')) instanceof ContentObjectRenderer
-            ? $contentObject
-            : GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        try {
+            return ($contentObject = $this->getRequest()?->getArgument('currentContentObject')) instanceof ContentObjectRenderer
+                ? $contentObject
+                : GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        } catch (NoSuchArgumentException $e) {
+            return GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        }
     }
 
     /**


### PR DESCRIPTION
If there was no "currentContentObject" set in the request, the new instance of ContentObjectRenderer was never reached and lead to an exception