### PR TITLE
[BUGFIX] Fixes array_key_exists(): Argument #1 ($key) must be a valid…

### DIFF
--- a/typo3/sysext/form/Classes/Controller/FormEditorController.php
+++ b/typo3/sysext/form/Classes/Controller/FormEditorController.php
@@ -571,7 +571,7 @@ class FormEditorController extends AbstractBackendController
         foreach ($formDefinition as $key => $value) {
             $identifier = $value[$identifierProperty] ?? null;
 
-            if (array_key_exists($identifier, $multiValueProperties)) {
+            if (is_string($identifier) && array_key_exists($identifier, $multiValueProperties)) {
                 $multiValuePropertiesForIdentifier = $multiValueProperties[$identifier];
 
                 foreach ($multiValuePropertiesForIdentifier as $multiValueProperty) {


### PR DESCRIPTION
… array offset type

Fixes the error

`array_key_exists(): Argument #1 ($key) must be a valid array offset type`

This error occurs, for example, when the SaveToDatabase finisher tries to map a field with the name "type". In `transformMultiValuePropertiesForFormEditor` there is no check as to whether the form element type determined there is actually an identifier (string) or not.