### PR TITLE
Fixes PHP-syntax in snippet

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/12.0/Feature-97305-IntroduceCSRF-likeRequest-tokenHandling.rst
+++ b/typo3/sysext/core/Documentation/Changelog/12.0/Feature-97305-IntroduceCSRF-likeRequest-tokenHandling.rst
@@ -167,7 +167,7 @@ can be used to generate the token individually.
             // validate individual requirements/checks
             // ...
             $event->setRequestToken(
-                RequestToken::create('core/user-auth/' . $user->loginType);
+                RequestToken::create('core/user-auth/' . $user->loginType)
             );
         }
     }


### PR DESCRIPTION
No semi-colon after method argument is needed/allowed.