### PR TITLE
[DOC] Improve output of *rootPaths examples

### DIFF
--- a/typo3/sysext/form/Documentation/D/FrontendRendering/Index.rst
+++ b/typo3/sysext/form/Documentation/D/FrontendRendering/Index.rst
@@ -35,9 +35,11 @@ Within this paths, fluid will search for a file which is named like the ``<formE
 
 For example:
 
-templateRootPaths.10 = EXT:form/Resources/Private/Frontend/Templates/
-$renderable->getType() == 'Form'
-Expected template file: EXT:form/Resources/Private/Frontend/Templates/Form.html
+.. code-block:: none
+
+   templateRootPaths.10 = EXT:form/Resources/Private/Frontend/Templates/
+   $renderable->getType() == 'Form'
+   Expected template file: EXT:form/Resources/Private/Frontend/Templates/Form.html
 
 Only the root element (``FormDefinition``) has to be a template file. All child form elements are partials. By default, the root element is called ``Form``.
 
@@ -83,9 +85,11 @@ Within this paths, fluid will search for a file which is named like the ``<formE
 
 For example:
 
-templateRootPaths.10 = EXT:form/Resources/Private/Frontend/Partials/
-$renderable->getType() == 'Text'
-Expected template file: EXT:form/Resources/Private/Frontend/Partials/Text.html
+.. code-block:: none
+
+   templateRootPaths.10 = EXT:form/Resources/Private/Frontend/Partials/
+   $renderable->getType() == 'Text'
+   Expected template file: EXT:form/Resources/Private/Frontend/Partials/Text.html
 
 There is a setting available to set a custom partial name. Please read the section :ref:`templateName<apireference-frontendrendering-fluidformrenderer-options-templatename>`.
 
@@ -109,17 +113,21 @@ By default, the renderable type will be taken as the name for the partial.
 
 For example:
 
-partialRootPaths.10 = EXT:form/Resources/Private/Frontend/Partials/
-$renderable->getType() == 'Text'
-Expected partial file: EXT:form/Resources/Private/Frontend/Partials/Text.html
+.. code-block:: none
+
+   partialRootPaths.10 = EXT:form/Resources/Private/Frontend/Partials/
+   $renderable->getType() == 'Text'
+   Expected partial file: EXT:form/Resources/Private/Frontend/Partials/Text.html
 
 Set ``templateName`` to define a custom name which should be used instead.
 
 For example:
 
-$renderable->getTemplateName() == 'Text'
-$renderable->getType() = Foo
-Expected partial file: EXT:form/Resources/Private/Frontend/Partials/Text.html
+.. code-block:: none
+
+   $renderable->getTemplateName() == 'Text'
+   $renderable->getType() = Foo
+   Expected partial file: EXT:form/Resources/Private/Frontend/Partials/Text.html
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Maybe there is also a better way to display this? Currently the line breaks aren't visible, which makes it quite hard to understand.

https://docs.typo3.org/c/typo3/cms-form/main/en-us/D/FrontendRendering/Index.html