### PR TITLE
[bugfix][#102993] streamline handling for absolute paths

### DIFF
--- a/typo3/sysext/core/Classes/Utility/GeneralUtility.php
+++ b/typo3/sysext/core/Classes/Utility/GeneralUtility.php
@@ -2437,8 +2437,7 @@ class GeneralUtility
 
         // Absolute path, but set to blank if not inside allowed directories.
         if (PathUtility::isAbsolutePath($fileName)) {
-            if (str_starts_with($fileName, Environment::getProjectPath()) ||
-                str_starts_with($fileName, Environment::getPublicPath())) {
+            if (static::isAllowedAbsPath($fileName)) {
                 return $checkForBackPath($fileName);
             }
             return '';


### PR DESCRIPTION
The widely used GeneralUtility::getFileAbsFileName method implemented its own check if the absolute path should be allowed to be accessed. It did not take the setting BE.lockRootPath into account.