### PR TITLE
[BUGFIX] Prevent 503 error when field is NULL

### DIFF
--- a/typo3/sysext/backend/Classes/Preview/StandardContentPreviewRenderer.php
+++ b/typo3/sysext/backend/Classes/Preview/StandardContentPreviewRenderer.php
@@ -384,7 +384,7 @@ class StandardContentPreviewRenderer implements PreviewRendererInterface, Logger
             $table = 'sys_category';
             $field = 'selected_categories';
         }
-        if (trim($record[$field]) === '') {
+        if (trim($record[$field] ?? '') === '') {
             return '';
         }
         $content = '';


### PR DESCRIPTION
Our editors managed to trigger a 503 error (message: `trim() expects parameter 1 to be string, null given`) in the backend page module by creating `menu_categorized_content` objects with `selected_categories`, then turning them into `menu_section` objects.

Having any value set in DB for `selected_categories` is apparently enough to enter `StandardContentPreviewRenderer::generateListForMenuContentTypes` .
https://github.com/TYPO3/typo3/blob/11.5/typo3/sysext/backend/Classes/Preview/StandardContentPreviewRenderer.php#L198 even if the CType doesn't use it.

A possible fix could be to check the right field for the right CType. But a perhaps more robust and flexible solution would be to ensure NULL values would be turned into empty strings.

# How to reproduce

Reproduced with TYPO3 version 11.5.34

1. On a new page, create a `menu_categorized_content` ContentElement, and select one category in `selected_categories`
2. Save
3. Update the CType to be `menu_section`
4. Save and close
5. Opening the page module for it will result in the following exception:

> Whoops, looks like something went wrong.
> (1/1) TypeError
> 
> trim() expects parameter 1 to be string, null given
