### PR TITLE
Admin-only edit lock can be disabled again in v11.5

### DIFF
--- a/typo3/sysext/beuser/Classes/Controller/PermissionController.php
+++ b/typo3/sysext/beuser/Classes/Controller/PermissionController.php
@@ -198,7 +198,7 @@ class PermissionController
                 break;
             case 'toggle_edit_lock':
                 // Initialize requested lock state
-                $editLockState = !$conf['editLockState'];
+                $editLockState = $conf['editLockState'] ? 0 : 1;
 
                 // Execute TCE Update
                 $tce->start([


### PR DESCRIPTION
Fixes the Doctrine error:
Incorrect integer value: '' for column 'editlock' at row 1

See https://forge.typo3.org/issues/103461