### PR TITLE
Update README.md to include MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This document provides a basic introduction to TYPO3.
 Getting Started
 ---------------
 
-TYPO3 requires a web server with PHP and a database (e.g. MySQL).
+TYPO3 requires a web server with PHP and a database (e.g. MySQL/MariaDB).
 The backend is accessed via a supported browser.
 
 Please see the [Installation Guide](https://docs.typo3.org/installation)


### PR DESCRIPTION
Considering typo3 works with MariaDB (see the download page https://get.typo3.org/), I humbly suggest adding a mention of MariaDB to the README.md file, i.e. "MySQL/MariaDB" to clarify this aspect and remove any doubt. Cheers!