### PR TITLE
[DOCS] Correct example for defining RTE preset of flexform field

### DIFF
--- a/typo3/sysext/rte_ckeditor/Documentation/Configuration/ConfigureTypo3.rst
+++ b/typo3/sysext/rte_ckeditor/Documentation/Configuration/ConfigureTypo3.rst
@@ -40,9 +40,9 @@ Page TSconfig can be used to change:
       RTE.config.tt_content.bodytext.preset = myCustomPreset
       RTE.config.tx_news_domain_model_news.bodytext.preset = minimal
 
-#. Override for one field defined in flexform (:typoscript:`RTE.config.[tableName].[flexForm.field.name].preset`)::
+#. Override for one field defined in flexform (:typoscript:`RTE.config.[tableName].[flexForm\.field\.name].preset`)::
 
-      RTE.config.tt_content.settings.notifications.emailText.preset = myCustomPreset
+      RTE.config.tt_content.settings\.notifications\.emailText.preset = myCustomPreset
 
 #. Override for one field, if type matches (:typoscript:`RTE.config.[tableName].[fieldName].types.[type].preset`)::
 


### PR DESCRIPTION
When addressing flexform fields in TSconfig, the dots of the field names have to be escaped with a backslash.