### PR TITLE
Fix Typos in Widget Documentation

### DIFF
--- a/typo3/sysext/dashboard/Documentation/Configuration/WidgetSettings.rst
+++ b/typo3/sysext/dashboard/Documentation/Configuration/WidgetSettings.rst
@@ -11,14 +11,14 @@ Therefore it is possible to override widgets.
 In order to override, the extension which should override has to be loaded after the extension that registered the widget.
 
 Concrete options depend on the widget to configure.
-Each widget should provide an documentation covering all possible options and their meaning.
+Each widget should provide a documentation covering all possible options and their meaning.
 For delivered widgets by ext:dashboard see :ref:`widgets`.
 
-In case an widget defined by ext:dashboard should be adjusted,
+In case a widget defined by ext:dashboard should be adjusted,
 the extension has to define a dependency to ext:dashboard.
 
 Afterwards the widget can be registered again, with different options. See
-:ref:`register-new-widget` to get an in depth example of how to register an widget.
+:ref:`register-new-widget` to get an in depth example of how to register a widget.
 
 Why not adjust specific settings?
 ---------------------------------
@@ -26,4 +26,4 @@ Why not adjust specific settings?
 There is no documented way to adjust specific settings,
 as this would result in a situation where multiple extensions are loaded in different order
 changing settings of widgets.
-That would lead to an complex system.
+That would lead to a complex system.


### PR DESCRIPTION
I found typos in the documentation.

Link: https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/Configuration/WidgetSettings.html