### PR TITLE
Fix registration code for custom admin panel modules

### DIFF
--- a/typo3/sysext/adminpanel/Documentation/Extending/Index.rst
+++ b/typo3/sysext/adminpanel/Documentation/Extending/Index.rst
@@ -44,10 +44,8 @@ To create your own Admin Panel module
    .. code-block:: php
 
       $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['adminpanel']['modules']['mynamespace_modulename'] = [
-          'module' => [
-              \Your\Namespace\Adminpanel\Modules\YourModule::class,
-              'before' => ['cache'],
-          ]
+          'module' => \Your\Namespace\Adminpanel\Modules\YourModule::class,
+          'before' => ['cache'],
       ];
 
 Using `before` or `after` you can influence where your module will be


### PR DESCRIPTION
The configuration array had one level of nesting in exceed. This resulted in run time errors if you took the provided registration code.