### PR TITLE
[BUGFIX] Fixes incorrect namespace of AbstractModule

### DIFF
--- a/typo3/sysext/adminpanel/Documentation/Extending/Index.rst
+++ b/typo3/sysext/adminpanel/Documentation/Extending/Index.rst
@@ -26,7 +26,7 @@ To create your own Admin Panel module
 =====================================
 
 #. Create a new PHP class extending
-   `\TYPO3\CMS\Adminpanel\Modules\AbstractModule`.
+   `\TYPO3\CMS\Adminpanel\ModuleApi\AbstractModule`.
 
 #. Implement at least the following methods:
 


### PR DESCRIPTION
The AbstractModule class is located within the 'ModuleApi' folder, so the namespace must be \TYPO3\CMS\Adminpanel\ModuleApi\AbstractModule. This patch fixes the issue.