### PR TITLE
[BUGFIX] Fix RequestHandler to support more specific html lang attribute

### DIFF
--- a/typo3/sysext/frontend/Classes/Http/RequestHandler.php
+++ b/typo3/sysext/frontend/Classes/Http/RequestHandler.php
@@ -300,8 +300,15 @@ class RequestHandler implements RequestHandlerInterface
         if (!empty($docTypeParts)) {
             $pageRenderer->setXmlPrologAndDocType(implode(LF, $docTypeParts));
         }
+        
         // See https://www.w3.org/International/questions/qa-html-language-declarations.en.html#attributes
-        $htmlTagAttributes[$docType->isXmlCompliant() ? 'xml:lang' : 'lang'] = $siteLanguage->getLocale()->getLanguageCode();
+        // and https://datatracker.ietf.org/doc/html/rfc5646
+        $htmlLangAttribute = $siteLanguage->getLocale()->getLanguageCode();
+        $siteLanguageHreflang = $siteLanguage->getHreflang(true);
+        if ($siteLanguageHreflang !== '') {
+            $htmlLangAttribute = $siteLanguageHreflang;
+        }
+        $htmlTagAttributes[$docType->isXmlCompliant() ? 'xml:lang' : 'lang'] = $htmlLangAttribute;
 
         if ($docType->isXmlCompliant() || $docType === DocType::html5 && $xmlDocument) {
             // We add this to HTML5 to achieve a slightly better backwards compatibility


### PR DESCRIPTION
Add support for more specific html lang attribute like: 

de-CH, en-GB a.s.o.

Use hreflink setting or fallback to the language setting from site configuration.

Resolves: #102178