### PR TITLE
Update Important-102786-UpdatedDependencySymfony7.rst

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/13.0/Important-102786-UpdatedDependencySymfony7.rst
+++ b/typo3/sysext/core/Documentation/Changelog/13.0/Important-102786-UpdatedDependencySymfony7.rst
@@ -3,7 +3,7 @@
 .. _important-102786-1704811367:
 
 ==================================================
-Important: #102786 - Updated dependency: Symfony 7
+Important: #102786 - Updated Dependency: Symfony 7
 ==================================================
 
 See :issue:`102786`


### PR DESCRIPTION
In the given sentence, "Dependency" is capitalized because it appears at the beginning of a title, follows a colon, and functions as a noun.