### PR TITLE
[DOCS] Add missing html template view statement in BarChartWidget.rst

### DIFF
--- a/typo3/sysext/dashboard/Documentation/Widgets/BarChartWidget.rst
+++ b/typo3/sysext/dashboard/Documentation/Widgets/BarChartWidget.rst
@@ -28,6 +28,7 @@ Example
        class: 'TYPO3\CMS\Dashboard\Widgets\BarChartWidget'
        arguments:
          $dataProvider: '@TYPO3\CMS\Dashboard\Widgets\Provider\SysLogErrorsDataProvider'
+         $view: '@dashboard.views.widget'
          $buttonProvider: '@TYPO3\CMS\Dashboard\Widgets\Provider\SysLogButtonProvider'
          $options:
             refreshAvailable: true


### PR DESCRIPTION
Encountered the error: 

Core: Exception handler (WEB): Uncaught TYPO3 Exception: #1257246929: Tried resolving a template file for controller action "Standard->widget/ChartWidget" in format ".html", but none of the paths contained the expected template file (Standard/Widget/ChartWidget.html). No paths configured. | TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException thrown in file /var/www/html/vendor/typo3fluid/fluid/src/View/TemplatePaths.php in line 595. Requested URL: https://mysite.ddev.site:8443/typo3/ajax/dashboard/widget/content?token=--AnonymizedToken--&widget=sysLogErrorsMyWidget

To add the small view statement helped. Seems to be an error when comparing with file cms-dashboard/Configuration/Backend/DashboardWidgets.yaml.