### PR TITLE
Update Breaking-82878-RemovedFieldNoCacheInDatabaseTablePages.rst

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/9.0/Breaking-82878-RemovedFieldNoCacheInDatabaseTablePages.rst
+++ b/typo3/sysext/core/Documentation/Changelog/9.0/Breaking-82878-RemovedFieldNoCacheInDatabaseTablePages.rst
@@ -26,7 +26,7 @@ Affected Installations
 
 Existing installations having this option set in their database.
 
-This can easily be checked via a SQL query: :sql:`SELECT uid, pid, title, FROM pages WHERE deleted=0
+This can easily be checked via a SQL query: :sql:`SELECT uid, pid, title FROM pages WHERE deleted=0
 AND pid>=0 AND no_cache=1;`.
 
 


### PR DESCRIPTION
Either there is a field missing in the statement or the comma is just an error. With the comma, the statement is invalid.