### PR TITLE
[DOCS] DatePicker instead of AdvancedPassword

### DIFF
--- a/typo3/sysext/form/Documentation/I/Config/proto/formElements/formElementTypes/DatePicker/formEditor/editors/500.rst.txt
+++ b/typo3/sysext/form/Documentation/I/Config/proto/formElements/formElementTypes/DatePicker/formEditor/editors/500.rst.txt
@@ -4,7 +4,7 @@ formEditor.editors.500
 ----------------------
 
 :aspect:`Option path`
-      prototypes.<prototypeIdentifier>.formElementsDefinition.AdvancedPassword.formEditor.editors.500
+      prototypes.<prototypeIdentifier>.formElementsDefinition.DatePicker.formEditor.editors.500
 
 :aspect:`Data type`
       array/ :ref:`[CheckboxEditor] <prototypes.prototypeIdentifier.formelementsdefinition.formelementtypeidentifier.formeditor.editors.*.checkboxeditor>`
@@ -23,7 +23,7 @@ formEditor.editors.500
          :linenos:
          :emphasize-lines: 4-
 
-         AdvancedPassword:
+         DatePicker:
            formEditor:
              editors:
                500:


### PR DESCRIPTION
AT this documentation about Form DatePicker https://docs.typo3.org/c/typo3/cms-form/main/en-us/I/Config/proto/formElements/formElementTypes/DatePicker.html#formeditor-editors-500

is AdvancedPassword used