### PR TITLE
Remove unnecessary checks for rendering the record list search box

### DIFF
--- a/typo3/sysext/backend/Classes/Controller/RecordListController.php
+++ b/typo3/sysext/backend/Classes/Controller/RecordListController.php
@@ -190,7 +190,7 @@ class RecordListController
             $pageTranslationsHtml = $this->renderPageTranslations($dbList, $siteLanguages);
         }
         $searchBoxHtml = '';
-        if ($this->allowSearch && $this->moduleData->get('searchBox') && ($tableListHtml || !empty($this->searchTerm))) {
+        if ($this->allowSearch && $this->moduleData->get('searchBox')) {
             $searchBoxHtml = $this->renderSearchBox($request, $dbList, $this->searchTerm, $search_levels);
         }
         $clipboardHtml = '';


### PR DESCRIPTION
Having this check `$tableListHtml || !empty($this->searchTerm` prevents the rendering of the search box if no search term is present and also no items exist on the current page.

When using a table filter it could be possible that items are available in sub pages, but since the search level selector is bound to the search box it is impossible to change the level and adjust the search depth.

To try it yourself just open a random parent page with some table filter of items not directly on that page and try to find items in sub pages - e.g. `/typo3/module/web/list?id=1&table=sys_category`

I couldn't think of any reason why this restriction would be necessary.