### PR TITLE
Prevent "id" parameter in backend URLs if not passed

### DIFF
--- a/typo3/sysext/extbase/Classes/Mvc/Web/Routing/UriBuilder.php
+++ b/typo3/sysext/extbase/Classes/Mvc/Web/Routing/UriBuilder.php
@@ -454,11 +454,6 @@ class UriBuilder
                 parse_str($argumentToBeExcluded, $argumentArrayToBeExcluded);
                 $arguments = ArrayUtility::arrayDiffKeyRecursive($arguments, $argumentArrayToBeExcluded);
             }
-        } else {
-            $id = $this->request->getParsedBody()['id'] ?? $this->request->getQueryParams()['id'] ?? null;
-            if ($id !== null) {
-                $arguments['id'] = $id;
-            }
         }
         if (($route = $this->request->getAttribute('route')) instanceof Route) {
             /** @var Route $route */


### PR DESCRIPTION
In TYPO3 v13, namespaced URL GET parameters are not supported any more and the URLs look like "/typo3/module/web/aimeos/Jsonadm/index?token=...".

If the Extbase plugin uses an "id" parameter to identify a record, this "id" parameter will be added by buildBackendUri() to all links generated for that request, even if the generated links must not include an "id" parameter, e.g. when searching in repositories and the "id" parameter is used to switch between retrieving a single item and retrieving a list of items.

This behavior seems to be a left-over from previous TYPO3 versions.