### PR TITLE
Update browse-files.ts DOM Text Interpreted as HTML

### DIFF
--- a/Build/Sources/TypeScript/filelist/browse-files.ts
+++ b/Build/Sources/TypeScript/filelist/browse-files.ts
@@ -85,7 +85,7 @@ class BrowseFiles {
       .then((response: AjaxResponse) => response.resolve())
       .then((response) => {
         const contentContainer = document.querySelector('.element-browser-main-content .element-browser-body') as HTMLElement;
-        contentContainer.innerHTML = response;
+        contentContainer.textContent = response;
       });
   }
 


### PR DESCRIPTION
Description:
By using textContent, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text.
This helps make page more safer as compare to innerHTML and prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.