### PR TITLE
Update "Breaking 101948" to add a yet undcomented break.

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/13.0/Breaking-101948-FileBasedAbstractRepositoryClassRemoved.rst
+++ b/typo3/sysext/core/Documentation/Changelog/13.0/Breaking-101948-FileBasedAbstractRepositoryClassRemoved.rst
@@ -41,6 +41,10 @@ that arose around :php:`AbstractRepository`.
 extend from this class anymore, as they only include the methods required for
 their purpose, and are now completely strictly typed.
 
+Additionaly :php:`FileRepository` has been cleaned up by removing
+:php:`findFileReferenceByUid()` as it is only a wrapper to 
+:php:`ResourceFactory::getFileReferenceObject()`
+
 
 Impact
 ======
@@ -50,6 +54,8 @@ implementing PHP repositories :php:`FileRepository` and
 :php:`ProcessedFileRepository` have only necessary methods available.
 
 PHP extensions that derive from the :php:`AbstractRepository` will stop working.
+
+Code that used :php:`FileRepository::findFileReferenceByUid()` will break.
 
 
 Affected installations
@@ -73,5 +79,19 @@ themselves and remove the dependency from :php:`AbstractRepository`.
 It is highly recommended to not use any of these classes, but rather stick
 to high-level API of FAL, such as :php:`ResourceFactory`, :php:`File`
 or :php:`ResourceStorage`.
+
+Replace calls to :php:`FileRepository::findFileReferenceByUid()` in this manner:
+
+.. code-block:: php
+
+    $fileRepository = GeneralUtility::makeInstance(FileRepository::class);
+    $reference = $fileRepository->findFileReferenceByUid($referenceUid);
+
+With code like that:
+
+.. code-block:: php
+
+   $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
+   $reference = $resourceFactory->getFileReferenceObject($referenceUid);
 
 .. index:: FAL, PHP-API, PartiallyScanned, ext:core


### PR DESCRIPTION
FileRepository::findFileReferenceByUid() has been removed. This breaking change was undocumented.