### PR TITLE
[DOCS]  EMU::addPlugin was changed but not EMU::addTcaSelectItemGroup

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/14.0/Breaking-105377-DeprecatedFunctionalityRemoved.rst
+++ b/typo3/sysext/core/Documentation/Changelog/14.0/Breaking-105377-DeprecatedFunctionalityRemoved.rst
@@ -138,7 +138,7 @@ The following methods changed signature according to previous deprecations in v1
 - :php:`\TYPO3\CMS\Core\Resource\ResourceStorage->moveFile()` (argument 4 is now of type :php:`\TYPO3\CMS\Core\Resource\Enum\DuplicationBehavior`)
 - :php:`\TYPO3\CMS\Core\Resource\ResourceStorage->moveFolder()` (argument 4 is now of type :php:`\TYPO3\CMS\Core\Resource\Enum\DuplicationBehavior`)
 - :php:`\TYPO3\CMS\Core\Resource\ResourceStorage->renameFile()` (argument 3 is now of type :php:`\TYPO3\CMS\Core\Resource\Enum\DuplicationBehavior`)
-- :php:`\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItemGroup()` (argument 2 :php:`$type` and 3 :php:`$extensionKey` have been dropped)
+- :php:`\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin()` (argument 2 :php:`$type` and 3 :php:`$extensionKey` have been dropped)
 
 The following public class properties have been dropped:
 


### PR DESCRIPTION
Follow up for https://review.typo3.org/c/Packages/TYPO3.CMS/+/86879

EMU::addPlugin was changed but not EMU::addTcaSelectItemGroup https://review.typo3.org/c/Packages/TYPO3.CMS/+/86879/13/typo3/sysext/core/Classes/Utility/ExtensionManagementUtility.php#b847

The parameters passed to EMU::addTcaSelectItemGroup have not been changed even when compared to 12.4.

Releases: main