### PR TITLE
[DOCS] Correct Breaking-105377-DeprecatedFunctionalityRemoved.rst

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/14.0/Breaking-105377-DeprecatedFunctionalityRemoved.rst
+++ b/typo3/sysext/core/Documentation/Changelog/14.0/Breaking-105377-DeprecatedFunctionalityRemoved.rst
@@ -47,7 +47,7 @@ The following PHP interfaces changed:
 
 The following PHP class aliases that have previously been marked as deprecated with v13 have been removed:
 
-- :php:`\TYPO3\CMS\Backend\Attribute\AsController`
+- :php:`\TYPO3\CMS\\Backend\Attribute\Controller`
 - :php:`\TYPO3\CMS\Backend\FrontendBackendUserAuthentication`
 - :php:`\TYPO3\CMS\Core\Database\Schema\Types\EnumType`
 - :php:`\TYPO3\CMS\Core\View\FluidViewAdapter`


### PR DESCRIPTION
With https://review.typo3.org/c/Packages/TYPO3.CMS/+/86774

'TYPO3\\CMS\\Backend\\Attribute\\Controller' has been removed. \TYPO3\CMS\Backend\Attribute\AsController is still in place and was not deprecated before.

https://review.typo3.org/c/Packages/TYPO3.CMS/+/86774/6/typo3/sysext/backend/Migrations/Code/ClassAliasMap.php