### PR TITLE
Clearify the migration from arrays using the PHP spread operator

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/12.0/Breaking-96044-HardenMethodSignatureOfLogicalAndAndLogicalOr.rst
+++ b/typo3/sysext/core/Documentation/Changelog/12.0/Breaking-96044-HardenMethodSignatureOfLogicalAndAndLogicalOr.rst
@@ -65,4 +65,15 @@ easy and quickly done. Simply don't use an array:
         $query->equals('propertyName3', 'value3'),
     ));
 
+Alternatively you can use the spread operator :php:`...` to expand your array to arguments:
+
+..  code-block:: php
+
+    $query = $this->createQuery();
+    $arrayOfConditions = [];
+    $arrayOfConditions[] = $query->equals('propertyName1', 'value1');
+    $arrayOfConditions[] = $query->equals('propertyName2', 'value2');
+    $arrayOfConditions[] = $query->equals('propertyName3', 'value3');
+    $query->matching($query->logicalAnd(...array_values($arrayOfConditions)));
+
 .. index:: PHP-API, FullyScanned, ext:extbase


### PR DESCRIPTION
Quite often constraints should only be added under certain conditions to a logical AND or OR comparison. So composing a list/array of constraint is a quite common use case. The usage of the PHP spread operator makes the migration more easy.