### PR TITLE
[DOCS] Update user reference from backend to front-end user

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/13.1/Feature-103147-ProvideFullUserdataInPasswordRecoveryEmailInExtbackend.rst
+++ b/typo3/sysext/core/Documentation/Changelog/13.1/Feature-103147-ProvideFullUserdataInPasswordRecoveryEmailInExtbackend.rst
@@ -13,13 +13,13 @@ Description
 
 A new array variable :html:`{userData}` has been added to the password
 recovery FluidEmail object. It contains the values of all fields from
-the :sql:`be_users` table belonging to the affected backend user.
+the :sql:`fe_users` table belonging to the affected front-end user.
 
 
 Impact
 ======
 
 It is now possible to use the :html:`{userData}` variable in the password
-recovery FluidEmail to access data from the affected backend user.
+recovery FluidEmail to access data from the affected front-end user.
 
 .. index:: Backend, ext:backend


### PR DESCRIPTION
- Changed `be_users` to `fe_users` and updated the terminology from "backend user" to "front-end user" in the password recovery FluidEmail.
- The `{userData}` variable now correctly refers to front-end user data from the `fe_users` table.
- Clarified that this feature works in the front-end context.
