### PR TITLE
Update Breaking-102925-TemplateChangesInIndexedSearch.rst

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/13.0/Breaking-102925-TemplateChangesInIndexedSearch.rst
+++ b/typo3/sysext/core/Documentation/Changelog/13.0/Breaking-102925-TemplateChangesInIndexedSearch.rst
@@ -43,7 +43,7 @@ JavaScript via :html:`<f:asset.script>`:
 
 ..  code-block:: html
 
-    <f:asset.script identifier="indexed_search_pagination" src="EXT:indexed_search/Resources/Public/JavaScript/pagination.js" />
+    <f:asset.script useNonce="true" identifier="indexed_search_pagination" src="EXT:indexed_search/Resources/Public/JavaScript/pagination.js" />
 
 
 `is:pageBrowsingResults` has been replaced with a short HTML snippet:


### PR DESCRIPTION
Changed f:asset example, added "useNonce" so typo3 instances with csp rules enabled will have a working pagination as well.