### PR TITLE
[TASK] avoid loading metadata for files if not necessary

### DIFF
--- a/typo3/sysext/filelist/Classes/FileList.php
+++ b/typo3/sysext/filelist/Classes/FileList.php
@@ -1709,6 +1709,8 @@ class FileList
                 return $resource->getModificationTime() . 't';
             case 'crdate':
                 return $resource->getCreationTime() . 'c';
+            case 'file':
+                return (string)$resource->getUid();
             default:
                 return $resource->hasProperty($sortField) ? (string)$resource->getProperty($sortField) : '';
         }


### PR DESCRIPTION
The FAL has very poor performance, especially when dealing with many many files in one folder. TYPO3 will use a paginated view but will apply the pagination strategy only in the runtime after the driver has loaded all assets in one folder. But by avoiding accessing the metadata of a file the response time can still be reduced by a lot.

The default file-list rendering will sort by "file" which is the sys_file uid but will be obtained via the metadata aspect. This is not necessary as the file object should be able to return the uid without using the metadata aspect.

By simply adding one case to the getSortingValueForFile method i could reduce the response-time for a massive folder from 10 seconds to 5 seconds, which is substantial.

Please consider merging this low-hanging-fruit commit into V14/13/12, i don't want to work with custom patches :-/