### PR TITLE
Update Deprecation-100071-MagicRepositoryFindByMethods.rst

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/12.3/Deprecation-100071-MagicRepositoryFindByMethods.rst
+++ b/typo3/sysext/core/Documentation/Changelog/12.3/Deprecation-100071-MagicRepositoryFindByMethods.rst
@@ -80,3 +80,7 @@ those methods allow for multiple comparisons, called constraints.
 
 
 .. index:: PHP-API, NotScanned, ext:extbase
+
+..  attention::
+
+    Please note that the (not-magic) methods `findByUid()` and `findByIdentifier()` did NOT get deprecated or removed, and are still valid to be used. Using these methods will also by default not respect storage page settings, and fetch the object straight via its identifier.


### PR DESCRIPTION
Note that findByUid() and findByIdentifier() are not affected by the change. https://forge.typo3.org/issues/106600#change-542209