### PR TITLE
Update PageContentErrorHandler.php

### DIFF
--- a/typo3/sysext/core/Classes/Error/PageErrorHandler/PageContentErrorHandler.php
+++ b/typo3/sysext/core/Classes/Error/PageErrorHandler/PageContentErrorHandler.php
@@ -122,12 +122,11 @@ class PageContentErrorHandler implements PageErrorHandlerInterface
     {
         $parkedTsfe = $GLOBALS['TSFE'] ?? null;
         $GLOBALS['TSFE'] = null;
-
-        $result = $fetcher();
-
-        $GLOBALS['TSFE'] = $parkedTsfe;
-
-        return $result;
+        try {
+            return $fetcher();
+        } finally {
+            $GLOBALS['TSFE'] = $parkedTsfe;
+        }
     }
 
     /**


### PR DESCRIPTION
Always reconstitute TSFE

There's always problems with extbase, solr and pagenotfound handling.

When you call persistAll EXT:solr will initialize all Sites, Sites with Root Pages of type Shortcut to Access restricted pages will trigger PageNotFound handling. This will call stashEnvironment. The, always the error `Undefined array key "SERVER_NAME" in vendor/typo3/cms-core/Classes/Middleware/VerifyHostHeader.php line 97` appears and given exceptionalErrors, it will throw an exception which will be catched too late and TSFE is lost.