### PR TITLE
docs: add missing `selectOptions` in form editor YAML example

### DIFF
--- a/typo3/sysext/form/Documentation/I/Concepts/Autocomplete/_CustomFormSetupAutoCompleteOption.yaml
+++ b/typo3/sysext/form/Documentation/I/Concepts/Autocomplete/_CustomFormSetupAutoCompleteOption.yaml
@@ -5,7 +5,8 @@ prototypes:
         formEditor:
           editors:
             600:
-              # Choose an index that is not in use yet
-              12345:
-                value: 'cc-name'
-                label: 'cc-name - Full name as given on the payment instrument'
+              selectOptions:
+                # Choose an index that is not in use yet
+                12345:
+                  value: 'cc-name'
+                  label: 'cc-name - Full name as given on the payment instrument'


### PR DESCRIPTION
Without the 'selectOptions' node the option isn’t rendered in the inspector dropdown.