### PR TITLE
[TASK] Consistently use self::new in all ServiceProviders

### DIFF
--- a/typo3/sysext/backend/Classes/ServiceProvider.php
+++ b/typo3/sysext/backend/Classes/ServiceProvider.php
@@ -89,11 +89,12 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getApplication(ContainerInterface $container): Application
     {
-        $requestHandler = new MiddlewareDispatcher(
+        $requestHandler = self::new($container, MiddlewareDispatcher::class, [
             $container->get(RequestHandler::class),
             $container->get('backend.middlewares'),
-            $container
-        );
+            $container,
+        ]);
+
         return self::new($container, Application::class, [
             $requestHandler,
             $container->get(Context::class),
@@ -102,11 +103,11 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getRequestHandler(ContainerInterface $container): RequestHandler
     {
-        return new RequestHandler(
+        return self::new($container, RequestHandler::class, [
             $container->get(RouteDispatcher::class),
             $container->get(UriBuilder::class),
-            $container->get(ListenerProvider::class)
-        );
+            $container->get(ListenerProvider::class),
+        ]);
     }
 
     public static function getRouteDispatcher(ContainerInterface $container): RouteDispatcher
@@ -194,7 +195,7 @@ class ServiceProvider extends AbstractServiceProvider
             $methods = $options['methods'] ?? [];
             $aliases = $options['aliases'] ?? [];
             unset($options['path'], $options['methods'], $options['aliases']);
-            $route = new Route($path, $options);
+            $route = self::new($container, Route::class, [$path, $options]);
             if (count($methods) > 0) {
                 $route->setMethods($methods);
             }

--- a/typo3/sysext/core/Classes/Package/AbstractServiceProvider.php
+++ b/typo3/sysext/core/Classes/Package/AbstractServiceProvider.php
@@ -160,9 +160,9 @@ abstract class AbstractServiceProvider implements ServiceProviderInterface
             $mutationsInPackage = self::requireFile($fileName);
             foreach ($mutationsInPackage as $scope => $mutation) {
                 if (!isset($mutations[$scope])) {
-                    $mutations[$scope] = new Map();
+                    $mutations[$scope] = self::new($container, Map::class);
                 }
-                $origin = new MutationOrigin(MutationOriginType::package, $packageName);
+                $origin = self::new($container, MutationOrigin::class, [MutationOriginType::package, $packageName]);
                 $mutations[$scope][$origin] = $mutation;
             }
         }

--- a/typo3/sysext/core/Classes/ServiceProvider.php
+++ b/typo3/sysext/core/Classes/ServiceProvider.php
@@ -222,77 +222,79 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getListCommand(ContainerInterface $container): Command\ListCommand
     {
-        return new Command\ListCommand(
+        return self::new($container, Command\ListCommand::class, [
             $container,
-            $container->get(Core\BootService::class)
-        );
+            $container->get(Core\BootService::class),
+        ]);
     }
 
     public static function getHelpCommand(ContainerInterface $container): HelpCommand
     {
-        return new HelpCommand();
+        return self::new($container, HelpCommand::class);
     }
 
     public static function getSymfonyLintCommand(ContainerInterface $container): SymfonyLintCommand
     {
-        return new SymfonyLintCommand();
+        return self::new($container, SymfonyLintCommand::class);
     }
 
     public static function getSymfonyDumpCompletionCommand(ContainerInterface $container): SymfonyDumpCompletionCommand
     {
-        return new SymfonyDumpCompletionCommand();
+        return self::new($container, SymfonyDumpCompletionCommand::class);
     }
 
     public static function getCacheFlushCommand(ContainerInterface $container): Command\CacheFlushCommand
     {
-        return new Command\CacheFlushCommand(
+        return self::new($container, Command\CacheFlushCommand::class, [
             $container->get(Core\BootService::class),
-            $container->get('cache.di')
-        );
+            $container->get('cache.di'),
+        ]);
     }
 
     public static function getCacheWarmupCommand(ContainerInterface $container): Command\CacheWarmupCommand
     {
-        return new Command\CacheWarmupCommand(
+        return self::new($container, Command\CacheWarmupCommand::class, [
             $container->get(ContainerBuilder::class),
             $container->get(Package\PackageManager::class),
             $container->get(Core\BootService::class),
-            $container->get('cache.di')
-        );
+            $container->get('cache.di'),
+        ]);
     }
 
     public static function getDumpAutoloadCommand(ContainerInterface $container): Command\DumpAutoloadCommand
     {
-        return new Command\DumpAutoloadCommand();
+        return self::new($container, Command\DumpAutoloadCommand::class);
     }
 
     public static function getConsoleCommandApplication(ContainerInterface $container): Console\CommandApplication
     {
-        return new Console\CommandApplication(
+        return self::new($container, Console\CommandApplication::class, [
             $container->get(Context\Context::class),
             $container->get(Console\CommandRegistry::class),
             $container->get(SymfonyEventDispatcher::class),
             $container->get(Configuration\ConfigurationManager::class),
             $container->get(Core\BootService::class),
-            $container->get(Localization\LanguageServiceFactory::class)
-        );
+            $container->get(Localization\LanguageServiceFactory::class),
+        ]);
     }
 
     public static function getConsoleCommandRegistry(ContainerInterface $container): Console\CommandRegistry
     {
-        return new Console\CommandRegistry($container);
+        return self::new($container, Console\CommandRegistry::class, [$container]);
     }
 
     public static function getEventDispatcher(ContainerInterface $container): EventDispatcher\EventDispatcher
     {
-        return new EventDispatcher\EventDispatcher(
-            $container->get(EventDispatcher\ListenerProvider::class)
-        );
+        return self::new($container, EventDispatcher\EventDispatcher::class, [
+            $container->get(EventDispatcher\ListenerProvider::class),
+        ]);
     }
 
     public static function getEventListenerProvider(ContainerInterface $container): EventDispatcher\ListenerProvider
     {
-        return new EventDispatcher\ListenerProvider($container);
+        return self::new($container, EventDispatcher\ListenerProvider::class, [
+            $container,
+        ]);
     }
 
     public static function extendEventListenerProvider(
@@ -321,7 +323,7 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getContext(ContainerInterface $container): Context\Context
     {
-        return new Context\Context();
+        return self::new($container, Context\Context::class);
     }
 
     public static function getBootService(ContainerInterface $container): Core\BootService
@@ -329,15 +331,15 @@ class ServiceProvider extends AbstractServiceProvider
         if ($container->has('_early.boot-service')) {
             return $container->get('_early.boot-service');
         }
-        return new Core\BootService(
+        return self::new($container, Core\BootService::class, [
             $container->get(ContainerBuilder::class),
-            $container
-        );
+            $container,
+        ]);
     }
 
     public static function getPasswordHashFactory(ContainerInterface $container): Crypto\PasswordHashing\PasswordHashFactory
     {
-        return new Crypto\PasswordHashing\PasswordHashFactory();
+        return self::new($container, Crypto\PasswordHashing\PasswordHashFactory::class);
     }
 
     public static function getIconFactory(ContainerInterface $container): Imaging\IconFactory
@@ -466,7 +468,9 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getPackageDependentCacheIdentifier(ContainerInterface $container): Package\Cache\PackageDependentCacheIdentifier
     {
-        return new Package\Cache\PackageDependentCacheIdentifier($container->get(Package\PackageManager::class));
+        return self::new($container, Package\Cache\PackageDependentCacheIdentifier::class, [
+            $container->get(Package\PackageManager::class),
+        ]);
     }
 
     public static function getRegistry(ContainerInterface $container): Registry
@@ -511,7 +515,7 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getFileNameValidator(ContainerInterface $container): Resource\Security\FileNameValidator
     {
-        return new FileNameValidator();
+        return self::new($container, FileNameValidator::class);
     }
 
     public static function getStorageRepository(ContainerInterface $container): Resource\StorageRepository
@@ -521,14 +525,14 @@ class ServiceProvider extends AbstractServiceProvider
             $container->get(Database\ConnectionPool::class),
             $container->get(Resource\Driver\DriverRegistry::class),
             $container->get(FlexFormTools::class),
-            new FlexFormService(),
+            self::new($container, FlexFormService::class),
             $container->get(Log\LogManager::class)->getLogger(Resource\StorageRepository::class),
         ]);
     }
 
     public static function getDependencyOrderingService(ContainerInterface $container): Service\DependencyOrderingService
     {
-        return new Service\DependencyOrderingService();
+        return self::new($container, Service\DependencyOrderingService::class);
     }
 
     public static function getOpcodeCacheService(ContainerInterface $container): Service\OpcodeCacheService
@@ -538,7 +542,10 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getTypoScriptStringFactory(ContainerInterface $container): TypoScript\TypoScriptStringFactory
     {
-        return new TypoScript\TypoScriptStringFactory($container, new LossyTokenizer());
+        return self::new($container, TypoScript\TypoScriptStringFactory::class, [
+            $container,
+            self::new($container, LossyTokenizer::class),
+        ]);
     }
 
     public static function getTypoScriptService(ContainerInterface $container): TypoScript\TypoScriptService
@@ -570,10 +577,10 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getHttpApplication(ContainerInterface $container): Http\Application
     {
-        $requestHandler = new Http\MiddlewareDispatcher(
+        $requestHandler = self::new($container, Http\MiddlewareDispatcher::class, [
             $container->get(Http\RequestHandler::class),
             $container->get('core.middlewares'),
-        );
+        ]);
 
         return self::new($container, Http\Application::class, [
             $requestHandler,
@@ -583,10 +590,10 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getHttpRequestHandler(ContainerInterface $container): Http\RequestHandler
     {
-        return new Http\RequestHandler(
+        return self::new($container, Http\RequestHandler::class, [
             $container,
             $container->get(Routing\BackendEntryPointResolver::class),
-        );
+        ]);
     }
 
     public static function getRequestContextFactory(ContainerInterface $container): Routing\RequestContextFactory
@@ -612,14 +619,14 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getGuzzleClientFactory(ContainerInterface $container): Http\Client\GuzzleClientFactory
     {
-        return new Http\Client\GuzzleClientFactory();
+        return self::new($container, Http\Client\GuzzleClientFactory::class);
     }
 
     public static function getRequestFactory(ContainerInterface $container): Http\RequestFactory
     {
-        return new Http\RequestFactory(
-            $container->get(Http\Client\GuzzleClientFactory::class)
-        );
+        return self::new($container, Http\RequestFactory::class, [
+            $container->get(Http\Client\GuzzleClientFactory::class),
+        ]);
     }
 
     public static function getReferrerEnforcer(ContainerInterface $container): Http\Security\ReferrerEnforcer
@@ -629,12 +636,12 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getMiddlewareStackResolver(ContainerInterface $container): Http\MiddlewareStackResolver
     {
-        return new Http\MiddlewareStackResolver(
+        return self::new($container, Http\MiddlewareStackResolver::class, [
             $container,
             $container->get(Service\DependencyOrderingService::class),
             $container->get('cache.core'),
             $container->get(Package\Cache\PackageDependentCacheIdentifier::class)->toString(),
-        );
+        ]);
     }
 
     public static function getMiddlewares(ContainerInterface $container): \ArrayObject
@@ -644,7 +651,7 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getContentSecurityPolicies(ContainerInterface $container): Map
     {
-        return new Map();
+        return self::new($container, Map::class);
     }
 
     public static function getAssetsCache(ContainerInterface $container): FrontendInterface
@@ -667,9 +674,9 @@ class ServiceProvider extends AbstractServiceProvider
         return new \ArrayObject($container->get(Http\MiddlewareStackResolver::class)->resolve('core'));
     }
 
-    public static function getHashService(): HashService
+    public static function getHashService(ContainerInterface $container): HashService
     {
-        return new HashService();
+        return self::new($container, HashService::class);
     }
 
     public static function provideFallbackEventDispatcher(
@@ -677,9 +684,9 @@ class ServiceProvider extends AbstractServiceProvider
         ?EventDispatcherInterface $eventDispatcher = null
     ): EventDispatcherInterface {
         // Provide a dummy / empty event dispatcher for the install tool when $eventDispatcher is null (that means when we run without symfony DI)
-        return $eventDispatcher ?? new EventDispatcher\EventDispatcher(
-            new EventDispatcher\ListenerProvider($container)
-        );
+        return $eventDispatcher ?? self::new($container, EventDispatcher\EventDispatcher::class, [
+            self::new($container, EventDispatcher\ListenerProvider::class, [$container]),
+        ]);
     }
 
     public static function configureCommands(ContainerInterface $container, Console\CommandRegistry $commandRegistry): Console\CommandRegistry

--- a/typo3/sysext/dashboard/Classes/ServiceProvider.php
+++ b/typo3/sysext/dashboard/Classes/ServiceProvider.php
@@ -93,14 +93,14 @@ class ServiceProvider extends AbstractServiceProvider
         }
 
         foreach ($dashboardPresetsFromPackages as $identifier => $options) {
-            $preset = new DashboardPreset(
+            $preset = self::new($container, DashboardPreset::class, [
                 $identifier,
                 $options['title'],
                 $options['description'],
                 $options['iconIdentifier'],
                 $options['defaultWidgets'],
-                $options['showInWizard']
-            );
+                $options['showInWizard'],
+            ]);
             $dashboardPresetRegistry->registerDashboardPreset($preset);
         }
 
@@ -121,10 +121,10 @@ class ServiceProvider extends AbstractServiceProvider
         }
 
         foreach ($widgetGroupsFromPackages as $identifier => $options) {
-            $group = new WidgetGroup(
+            $group = self::new($container, WidgetGroup::class, [
                 $identifier,
-                $options['title']
-            );
+                $options['title'],
+            ]);
             $widgetGroupRegistry->registerWidgetGroup($group);
         }
 

--- a/typo3/sysext/fluid/Classes/ServiceProvider.php
+++ b/typo3/sysext/fluid/Classes/ServiceProvider.php
@@ -79,8 +79,8 @@ class ServiceProvider extends AbstractServiceProvider
         ?ViewFactoryInterface $viewFactory = null
     ): ViewFactoryInterface {
         // Provide the default FluidViewFactory for the install tool when $viewFactory is null (that means when we run without symfony DI)
-        return $viewFactory ?? new View\FluidViewFactory(
+        return $viewFactory ?? self::new($container, View\FluidViewFactory::class, [
             $container->get(Core\Rendering\RenderingContextFactory::class),
-        );
+        ]);
     }
 }

--- a/typo3/sysext/frontend/Classes/ServiceProvider.php
+++ b/typo3/sysext/frontend/Classes/ServiceProvider.php
@@ -60,11 +60,11 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getApplication(ContainerInterface $container): Http\Application
     {
-        $requestHandler = new MiddlewareDispatcher(
+        $requestHandler = self::new($container, MiddlewareDispatcher::class, [
             $container->get(Http\RequestHandler::class),
             $container->get('frontend.middlewares'),
-            $container
-        );
+            $container,
+        ]);
 
         return self::new($container, Http\Application::class, [
             $requestHandler,

--- a/typo3/sysext/install/Classes/ServiceProvider.php
+++ b/typo3/sysext/install/Classes/ServiceProvider.php
@@ -123,15 +123,19 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getAuthenticationService(ContainerInterface $container): Authentication\AuthenticationService
     {
-        return new Authentication\AuthenticationService(
-            $container->get(Mailer::class)
-        );
+        return self::new($container, Authentication\AuthenticationService::class, [
+            $container->get(Mailer::class),
+        ]);
     }
 
     public static function getApplication(ContainerInterface $container): Http\Application
     {
         $requestHandler = $container->get(Http\NotFoundRequestHandler::class);
-        $dispatcher = new MiddlewareDispatcher($requestHandler, [], $container);
+        $dispatcher = self::new($container, MiddlewareDispatcher::class, [
+            $requestHandler,
+            [],
+            $container,
+        ]);
 
         // Stack of middlewares, executed LIFO
         $dispatcher->lazy(ResponsePropagationMiddleware::class);
@@ -147,72 +151,72 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getNotFoundRequestHandler(ContainerInterface $container): Http\NotFoundRequestHandler
     {
-        return new Http\NotFoundRequestHandler();
+        return self::new($container, Http\NotFoundRequestHandler::class);
     }
 
     public static function getClearCacheService(ContainerInterface $container): Service\ClearCacheService
     {
-        return new Service\ClearCacheService(
+        return self::new($container, Service\ClearCacheService::class, [
             $container->get(Service\LateBootService::class),
-            $container->get('cache.di')
-        );
+            $container->get('cache.di'),
+        ]);
     }
 
     public static function getClearTableService(ContainerInterface $container): Service\ClearTableService
     {
-        return new Service\ClearTableService(
+        return self::new($container, Service\ClearTableService::class, [
             $container->get(FailsafePackageManager::class),
-        );
+        ]);
     }
 
     public static function getCoreUpdateService(ContainerInterface $container): Service\CoreUpdateService
     {
-        return new Service\CoreUpdateService(
-            $container->get(Service\CoreVersionService::class)
-        );
+        return self::new($container, Service\CoreUpdateService::class, [
+            $container->get(Service\CoreVersionService::class),
+        ]);
     }
 
     public static function getCoreVersionService(ContainerInterface $container): Service\CoreVersionService
     {
-        return new Service\CoreVersionService();
+        return self::new($container, Service\CoreVersionService::class);
     }
 
     public static function getLanguagePackService(ContainerInterface $container): Service\LanguagePackService
     {
-        return new Service\LanguagePackService(
+        return self::new($container, Service\LanguagePackService::class, [
             $container->get(EventDispatcherInterface::class),
             $container->get(RequestFactory::class),
-            $container->get(LogManager::class)->getLogger(Service\LanguagePackService::class)
-        );
+            $container->get(LogManager::class)->getLogger(Service\LanguagePackService::class),
+        ]);
     }
 
     public static function getLateBootService(ContainerInterface $container): Service\LateBootService
     {
-        return new Service\LateBootService(
+        return self::new($container, Service\LateBootService::class, [
             $container->get(ContainerBuilder::class),
-            $container
-        );
+            $container,
+        ]);
     }
 
     public static function getLoadTcaService(ContainerInterface $container): Service\LoadTcaService
     {
-        return new Service\LoadTcaService(
-            $container->get(Service\LateBootService::class)
-        );
+        return self::new($container, Service\LoadTcaService::class, [
+            $container->get(Service\LateBootService::class),
+        ]);
     }
 
     public static function getSilentConfigurationUpgradeService(ContainerInterface $container): Service\SilentConfigurationUpgradeService
     {
-        return new Service\SilentConfigurationUpgradeService(
-            $container->get(ConfigurationManager::class)
-        );
+        return self::new($container, Service\SilentConfigurationUpgradeService::class, [
+            $container->get(ConfigurationManager::class),
+        ]);
     }
 
     public static function getSilentTemplateFileUpgradeService(ContainerInterface $container): Service\SilentTemplateFileUpgradeService
     {
-        return new Service\SilentTemplateFileUpgradeService(
-            $container->get(WebServerConfigurationFileService::class)
-        );
+        return self::new($container, Service\SilentTemplateFileUpgradeService::class, [
+            $container->get(WebServerConfigurationFileService::class),
+        ]);
     }
 
     public static function getWebServerConfigurationFileService(ContainerInterface $container): Service\WebServerConfigurationFileService
@@ -227,71 +231,71 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function getSessionService(ContainerInterface $container): Service\SessionService
     {
-        return new Service\SessionService(
+        return self::new($container, Service\SessionService::class, [
             $container->get(HashService::class),
-        );
+        ]);
     }
 
     public static function getSetupService(ContainerInterface $container): Service\SetupService
     {
-        return new Service\SetupService(
+        return self::new($container, Service\SetupService::class, [
             $container->get(ConfigurationManager::class),
             $container->get(SiteWriter::class),
             $container->get(YamlFileLoader::class),
             $container->get(FailsafePackageManager::class),
-        );
+        ]);
     }
 
     public static function getSetupDatabaseService(ContainerInterface $container): Service\SetupDatabaseService
     {
-        return new Service\SetupDatabaseService(
+        return self::new($container, Service\SetupDatabaseService::class, [
             $container->get(Service\LateBootService::class),
             $container->get(ConfigurationManager::class),
             $container->get(PermissionsCheck::class),
             $container->get(Registry::class),
-        );
+        ]);
     }
 
     public static function getInstallerMiddleware(ContainerInterface $container): Middleware\Installer
     {
-        return new Middleware\Installer(
+        return self::new($container, Middleware\Installer::class, [
             $container,
             $container->get(FormProtectionFactory::class),
             $container->get(SessionService::class),
-        );
+        ]);
     }
 
     public static function getMaintenanceMiddleware(ContainerInterface $container): Middleware\Maintenance
     {
-        return new Middleware\Maintenance(
+        return self::new($container, Middleware\Maintenance::class, [
             $container->get(FailsafePackageManager::class),
             $container->get(ConfigurationManager::class),
             $container->get(PasswordHashFactory::class),
             $container,
             $container->get(FormProtectionFactory::class),
             $container->get(SessionService::class),
-        );
+        ]);
     }
 
     public static function getEnvironmentController(ContainerInterface $container): Controller\EnvironmentController
     {
-        return new Controller\EnvironmentController(
+        return self::new($container, Controller\EnvironmentController::class, [
             $container->get(Service\LateBootService::class),
             $container->get(FormProtectionFactory::class),
-            $container->get(Mailer::class)
-        );
+            $container->get(Mailer::class),
+        ]);
     }
 
     public static function getIconController(ContainerInterface $container): Controller\IconController
     {
-        return new Controller\IconController(
-            $container->get(IconFactory::class)
-        );
+        return self::new($container, Controller\IconController::class, [
+            $container->get(IconFactory::class),
+        ]);
     }
 
     public static function getInstallerController(ContainerInterface $container): Controller\InstallerController
     {
-        return new Controller\InstallerController(
+        return self::new($container, Controller\InstallerController::class, [
             $container->get(Service\LateBootService::class),
             $container->get(ConfigurationManager::class),
             $container->get(FailsafePackageManager::class),
@@ -301,32 +305,32 @@ class ServiceProvider extends AbstractServiceProvider
             $container->get(SetupDatabaseService::class),
             $container->get(HashService::class),
             $container->get(IconRegistry::class),
-        );
+        ]);
     }
 
     public static function getLayoutController(ContainerInterface $container): Controller\LayoutController
     {
-        return new Controller\LayoutController(
+        return self::new($container, Controller\LayoutController::class, [
             $container->get(FailsafePackageManager::class),
             $container->get(Service\SilentConfigurationUpgradeService::class),
             $container->get(Service\SilentTemplateFileUpgradeService::class),
             $container->get(BackendEntryPointResolver::class),
             $container->get(HashService::class),
             $container->get(IconRegistry::class),
-        );
+        ]);
     }
 
     public static function getLoginController(ContainerInterface $container): Controller\LoginController
     {
-        return new Controller\LoginController(
+        return self::new($container, Controller\LoginController::class, [
             $container->get(FormProtectionFactory::class),
             $container->get(ConfigurationManager::class),
-        );
+        ]);
     }
 
     public static function getMaintenanceController(ContainerInterface $container): Controller\MaintenanceController
     {
-        return new Controller\MaintenanceController(
+        return self::new($container, Controller\MaintenanceController::class, [
             $container->get(Service\LateBootService::class),
             $container->get(Service\ClearCacheService::class),
             $container->get(Service\ClearTableService::class),
@@ -335,12 +339,12 @@ class ServiceProvider extends AbstractServiceProvider
             $container->get(Locales::class),
             $container->get(LanguageServiceFactory::class),
             $container->get(FormProtectionFactory::class),
-        );
+        ]);
     }
 
     public static function getSettingsController(ContainerInterface $container): Controller\SettingsController
     {
-        return new Controller\SettingsController(
+        return self::new($container, Controller\SettingsController::class, [
             $container->get(PackageManager::class),
             $container->get(LanguageServiceFactory::class),
             $container->get(CommentAwareAstBuilder::class),
@@ -348,83 +352,83 @@ class ServiceProvider extends AbstractServiceProvider
             $container->get(AstTraverser::class),
             $container->get(FormProtectionFactory::class),
             $container->get(ConfigurationManager::class),
-        );
+        ]);
     }
 
     public static function getServerResponseCheckController(ContainerInterface $container): Controller\ServerResponseCheckController
     {
-        return new Controller\ServerResponseCheckController(
+        return self::new($container, Controller\ServerResponseCheckController::class, [
             $container->get(HashService::class),
-        );
+        ]);
     }
 
     public static function getUpgradeController(ContainerInterface $container): Controller\UpgradeController
     {
-        return new Controller\UpgradeController(
+        return self::new($container, Controller\UpgradeController::class, [
             $container->get(PackageManager::class),
             $container->get(Service\LateBootService::class),
             $container->get(Service\DatabaseUpgradeWizardsService::class),
             $container->get(FormProtectionFactory::class),
-            $container->get(LoadTcaService::class)
-        );
+            $container->get(LoadTcaService::class),
+        ]);
     }
 
     public static function getLanguagePackCommand(ContainerInterface $container): Command\LanguagePackCommand
     {
-        return new Command\LanguagePackCommand(
+        return self::new($container, Command\LanguagePackCommand::class, [
             'language:update',
-            $container->get(Service\LateBootService::class)
-        );
+            $container->get(Service\LateBootService::class),
+        ]);
     }
 
     public static function getUpgradeWizardRunCommand(ContainerInterface $container): Command\UpgradeWizardRunCommand
     {
-        return new Command\UpgradeWizardRunCommand(
+        return self::new($container, Command\UpgradeWizardRunCommand::class, [
             'upgrade:run',
             $container->get(Service\LateBootService::class),
             $container->get(Service\DatabaseUpgradeWizardsService::class),
-            $container->get(Service\SilentConfigurationUpgradeService::class)
-        );
+            $container->get(Service\SilentConfigurationUpgradeService::class),
+        ]);
     }
 
     public static function getUpgradeWizardListCommand(ContainerInterface $container): Command\UpgradeWizardListCommand
     {
-        return new Command\UpgradeWizardListCommand(
+        return self::new($container, Command\UpgradeWizardListCommand::class, [
             'upgrade:list',
             $container->get(Service\LateBootService::class),
-        );
+        ]);
     }
 
     public static function getUpgradeWizardMarkUndoneCommand(ContainerInterface $container): Command\UpgradeWizardMarkUndoneCommand
     {
-        return new Command\UpgradeWizardMarkUndoneCommand(
+        return self::new($container, Command\UpgradeWizardMarkUndoneCommand::class, [
             'upgrade:mark:undone',
             $container->get(Service\LateBootService::class),
-        );
+        ]);
     }
 
     public static function getSetupCommand(ContainerInterface $container): Command\SetupCommand
     {
-        return new Command\SetupCommand(
+        return self::new($container, Command\SetupCommand::class, [
             'setup',
             $container->get(Service\SetupDatabaseService::class),
             $container->get(Service\SetupService::class),
             $container->get(ConfigurationManager::class),
             $container->get(LateBootService::class),
-        );
+        ]);
     }
 
     public function getSetupDefaultBackendUserGroupsCommand(ContainerInterface $container): Command\SetupDefaultBackendUserGroupsCommand
     {
-        return new Command\SetupDefaultBackendUserGroupsCommand(
+        return self::new($container, Command\SetupDefaultBackendUserGroupsCommand::class, [
             'setup:begroups:default',
             $container->get(Service\SetupService::class),
-        );
+        ]);
     }
 
     public static function getPermissionsCheck(ContainerInterface $container): Database\PermissionsCheck
     {
-        return new Database\PermissionsCheck();
+        return self::new($container, Database\PermissionsCheck::class);
     }
 
     public static function configureCommands(ContainerInterface $container, CommandRegistry $commandRegistry): CommandRegistry


### PR DESCRIPTION
1. Consistency
2. Allows XCLASS for e.g. MiddlewareDispatcher for profiling issues