### PR TITLE
[BUGFIX] Remove only leading 'ajax_' prefix in Ajax route keys

### DIFF
--- a/typo3/sysext/core/Classes/Page/PageRenderer.php
+++ b/typo3/sysext/core/Classes/Page/PageRenderer.php
@@ -1531,7 +1531,9 @@ class PageRenderer implements SingletonInterface
             if ($route->getOption('ajax')) {
                 $uri = (string)$uriBuilder->buildUriFromRoute($routeIdentifier);
                 // use the shortened value in order to use this in JavaScript
-                $routeIdentifier = str_replace('ajax_', '', $routeIdentifier);
+                if (strncmp($routeIdentifier, 'ajax_', 5) === 0) {
+                    $routeIdentifier = substr($routeIdentifier, 5);
+                }
                 $ajaxUrls[$routeIdentifier] = $uri;
             }
         }


### PR DESCRIPTION
Previously, all occurrences of 'ajax_' were removed from Ajax route keys in TYPO3.settings.ajaxUrls, leading to mismatches between PHP and JS keys. Now, only a leading 'ajax_' prefix is stripped, preserving the rest of the key.

Resolves: #107095