### PR TITLE
[BUGFIX] Correct label syntax for FeLogin fields

### DIFF
--- a/typo3/sysext/felogin/Resources/Private/Templates/Login/Login.html
+++ b/typo3/sysext/felogin/Resources/Private/Templates/Login/Login.html
@@ -29,14 +29,14 @@
         <div>
             <label for="tx-felogin-input-username">
                 <f:translate key="username"/>
-                <f:form.textfield name="user" required="true" autocomplete="username" id="tx-felogin-input-username"/>
             </label>
+            <f:form.textfield name="user" required="true" autocomplete="username" id="tx-felogin-input-username"/>
         </div>
         <div>
             <label for="tx-felogin-input-password">
                 <f:translate key="password"/>
-                <f:form.password name="pass" required="required" autocomplete="current-password" id="tx-felogin-input-password"/>
             </label>
+            <f:form.password name="pass" required="required" autocomplete="current-password" id="tx-felogin-input-password"/>
         </div>
 
         <f:if condition="{permaloginStatus} > -1">

--- a/typo3/sysext/felogin/Resources/Private/Templates/PasswordRecovery/Recovery.html
+++ b/typo3/sysext/felogin/Resources/Private/Templates/PasswordRecovery/Recovery.html
@@ -16,8 +16,8 @@
         <div>
             <label for="tx-felogin-input-data">
                 <f:translate key="enter_your_data"/>
-                <f:form.textfield name="userIdentifier" id="tx-felogin-input-data"/>
             </label>
+            <f:form.textfield name="userIdentifier" id="tx-felogin-input-data"/>
         </div>
         <div>
             <f:form.submit value="{f:translate(key: 'reset_password')}"/>


### PR DESCRIPTION
This fixes the wrong syntax for labels in FE-Login Login and Password Recovery Fields.
Take a look into "A 3.3.2 Labels or Instructions" for Accessibility. "Form Field has wrong label syntax"