### PR TITLE
Show the former \PDO in the example

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/13.0/Breaking-102875-ChangedConnectionMethodSignaturesAndBehaviour.rst
+++ b/typo3/sysext/core/Documentation/Changelog/13.0/Breaking-102875-ChangedConnectionMethodSignaturesAndBehaviour.rst
@@ -74,8 +74,8 @@ Returns the last inserted ID (auto-created) on the connection.
             'some_string' => $someString,
         ],
         [
-            Typo3Connection::PARAM_INT,
-            Typo3Connection::PARAM_STR,
+            \PDO::PARAM_INT,
+            \PDO::PARAM_STR,
         ]
     );
     $uid = $connection->lastInsertId('tx_myextension_mytable');


### PR DESCRIPTION
The example misses the \PDO. 
This would help to search it in the docs.