### PR TITLE
[107337] Correct, simplify and speed up session garbage collection pr…

### DIFF
--- a/typo3/sysext/core/Classes/Session/UserSessionManager.php
+++ b/typo3/sysext/core/Classes/Session/UserSessionManager.php
@@ -276,12 +276,11 @@ class UserSessionManager implements LoggerAwareInterface
     }
 
     /**
-     * Calls the session backends `collectGarbage()` method
+     * Calls the session backends `collectGarbage()` method with the given probability in percent.
      */
     public function collectGarbage(int $garbageCollectionProbability = 1): void
     {
-        // If we're lucky we'll get to clean up old sessions
-        if (random_int(0, mt_getrandmax()) % 100 <= $garbageCollectionProbability) {
+        if (rand(0, 99) < $garbageCollectionProbability) {
             $this->sessionBackend->collectGarbage(
                 $this->sessionLifetime > 0 ? $this->sessionLifetime : self::GARBAGE_COLLECTION_LIFETIME,
                 $this->garbageCollectionForAnonymousSessions


### PR DESCRIPTION
…obability

The session garbage probability was calcluated wrongly. It randomly picked an integer between 0-99, but compared less-or-equal to the required probablity, so 99 counting falsely already as 100% and 1 counting falsesly as 2% (and so on). This is fixed by using a strict lesser-than comparison.

Also the random number generation was overcomplicated and statistically not uniform because it relied on the modulus of the divisor "100" being applied to a random number out of the range 0 to 2^31-1, whose maximum is not a multiple of 100, so the few "extra" numbers above the last whole multiple of 100 were a tiny bit more likely to be chosen (because they appear one time more often than the "missing" numbers up to 100 inside the "set" to randomly choose from). This was corrected by not taking the modulo of 100 of some huge random number, but by just getting a random number between 0-99 directly.

Also the cryptographically robust, but less than half as fast, function `random_int` was replaced by using `rand()` instead, to speed things up even further. Cryptographically robustness is not needed here.