### PR TITLE
[DOCS] Fix Linkvalidator Code Example

### DIFF
--- a/typo3/sysext/linkvalidator/Documentation/Configuration/_example.tsconfig
+++ b/typo3/sysext/linkvalidator/Documentation/Configuration/_example.tsconfig
@@ -12,8 +12,10 @@ mod.linkvalidator {
     replytoemail =
     subject = TYPO3 LinkValidator report
   }
-  external {
-    httpAgentUrl = https://example.org/info.html
-    httpAgentEmail = info@example.org
+  linktypesConfig {
+    external {
+      httpAgentUrl = https://example.org/info.html
+      httpAgentEmail = info@example.org
+    }
   }
 }


### PR DESCRIPTION
The example code is missing the key `linktypesConfig`. 