### PR TITLE
Move Table Garbage Collection deprecation

### DIFF
--- a/typo3/sysext/scheduler/Documentation/BasicTasks/GarbageCollection.rst
+++ b/typo3/sysext/scheduler/Documentation/BasicTasks/GarbageCollection.rst
@@ -8,13 +8,6 @@
 Table garbage collection task
 =============================
 
-..  deprecated:: 14.0
-    The previous configuration method using
-    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask::class]['options']['tables']`
-    has been deprecated and will be removed in TYPO3 v15.
-
-    See also: `Changelog Deprecation: #107550 - Table Garbage Collection Task configuration via $GLOBALS <https://docs.typo3.org/permalink/changelog:deprecation-107550-1736193200>`_
-
 The table garbage collection task can take a more elaborate
 configuration which is detailed below.
 
@@ -65,6 +58,13 @@ entries:
 
 Example: Configure additional tables for the "Garbage Collection" task
 ======================================================================
+
+..  deprecated:: 14.0
+    The previous configuration method using
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask::class]['options']['tables']`
+    has been deprecated and will be removed in TYPO3 v15.
+
+    See also: `Changelog Deprecation: #107550 - Table Garbage Collection Task configuration via $GLOBALS <https://docs.typo3.org/permalink/changelog:deprecation-107550-1736193200>`_
 
 ..  literalinclude:: _codesnippets/_tx_scheduler_garbage_collection.php.inc
     :language: php


### PR DESCRIPTION
This avoids the impression that the whole task is deprecated. 

People are very likely to read the headline and leave, even though the following text explains that the deprecation is only about the table registration.